### PR TITLE
feat(hooks): cherry-pick alpaca wheel behaviors into local guardrails

### DIFF
--- a/hooks/claude_code/hooks/enkrypt_guardrails.py
+++ b/hooks/claude_code/hooks/enkrypt_guardrails.py
@@ -621,6 +621,35 @@ def read_hook_input() -> Dict[str, Any]:
         return {}
 
 
+MAX_FILE_CHARS = 8000
+
+
+def _read_file_safe(path: str, max_chars: int = MAX_FILE_CHARS) -> Optional[str]:
+    """Read file contents as text, returning None for binary/unreadable files."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="strict") as f:
+            return f.read(max_chars)
+    except (UnicodeDecodeError, ValueError):
+        try:
+            with open(path, "r", encoding="latin-1") as f:
+                return f.read(max_chars)
+        except Exception:
+            return None
+    except (OSError, IOError):
+        return None
+
+
+def extract_file_content_for_read(tool_input: Dict[str, Any]) -> Optional[str]:
+    """Read actual file contents from disk when tool_name is Read.
+
+    Returns the file text (up to MAX_FILE_CHARS) or None if unreadable.
+    """
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        return None
+    return _read_file_safe(file_path)
+
+
 def extract_text_from_tool_input(tool_name: str, tool_input: Dict[str, Any]) -> str:
     """Extract text content from tool input for guardrails check."""
     text_parts = []

--- a/hooks/claude_code/hooks/notification.py
+++ b/hooks/claude_code/hooks/notification.py
@@ -26,9 +26,15 @@ Notification Types:
 - elicitation_dialog: When Claude Code needs input for MCP tool elicitation
 """
 
-import sys
 import json
 import os
+import sys
+
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from enkrypt_guardrails import (
     read_hook_input,

--- a/hooks/claude_code/hooks/permission_request.py
+++ b/hooks/claude_code/hooks/permission_request.py
@@ -36,8 +36,15 @@ Hook Output (JSON):
 }
 """
 
-import sys
 import json
+import os
+import sys
+
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from enkrypt_guardrails import (
     read_hook_input,

--- a/hooks/claude_code/hooks/post_tool_use.py
+++ b/hooks/claude_code/hooks/post_tool_use.py
@@ -35,8 +35,15 @@ Hook Output (JSON):
 }
 """
 
-import sys
 import json
+import os
+import sys
+
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from enkrypt_guardrails import (
     read_hook_input,

--- a/hooks/claude_code/hooks/pre_compact.py
+++ b/hooks/claude_code/hooks/pre_compact.py
@@ -24,8 +24,15 @@ Matchers:
 - auto: Invoked from auto-compact (full context window)
 """
 
-import sys
 import json
+import os
+import sys
+
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from enkrypt_guardrails import (
     read_hook_input,

--- a/hooks/claude_code/hooks/pre_tool_use.py
+++ b/hooks/claude_code/hooks/pre_tool_use.py
@@ -9,6 +9,11 @@ This hook runs before a tool is executed. It can:
 - Modify tool input (updatedInput)
 - Add context (additionalContext)
 
+For Read tool calls, the hook reads the target file from disk and scans
+the contents through Enkrypt AI Guardrails before the agent sees the data.
+This prevents sensitive file contents (PII, secrets, etc.) from reaching
+the model.
+
 Hook Input (via stdin):
 {
     "session_id": "abc123",
@@ -36,27 +41,95 @@ Hook Output (JSON):
 }
 """
 
-import sys
 import json
+import os
+import sys
 
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from enkrypt_guardrails import (
-    read_hook_input,
     check_with_enkrypt_api,
+    create_json_output,
+    extract_file_content_for_read,
+    extract_text_from_tool_input,
     is_hook_enabled,
     is_sensitive_tool,
-    extract_text_from_tool_input,
-    format_blocking_error,
-    create_json_output,
-    output_json,
-    output_error,
     log_event,
     log_security_alert,
+    output_json,
+    read_hook_input,
 )
+
+
+def _handle_file_read(tool_input, hook_name, session_id, tool_use_id, cwd):
+    """Scan file contents before allowing a Read tool call.
+
+    Returns (should_exit, exit_code) — if should_exit is True the caller
+    should ``sys.exit(exit_code)`` immediately.
+    """
+    file_path = tool_input.get("file_path", "")
+    content = extract_file_content_for_read(tool_input)
+
+    if not content or not content.strip():
+        log_event(
+            "file_read_scan_skipped",
+            {
+                "hook": hook_name,
+                "file_path": file_path,
+                "reason": "file unreadable or empty",
+            },
+        )
+        return False, 0
+
+    should_block, violations, raw_result = check_with_enkrypt_api(content, hook_name)
+
+    print(
+        f"\n[Enkrypt Guardrails - File: {os.path.basename(file_path)}]\n"
+        f"{json.dumps(raw_result, indent=2)}",
+        file=sys.stderr,
+    )
+
+    if should_block:
+        log_security_alert(
+            "file_read_blocked",
+            {
+                "tool_name": "Read",
+                "file_path": file_path,
+                "violations": violations,
+                "content_size": len(content),
+            },
+            {"session_id": session_id, "tool_use_id": tool_use_id, "cwd": cwd},
+        )
+
+        detector_names = [v["detector"] for v in violations]
+        output = create_json_output(
+            hook_event_name=hook_name,
+            permission_decision="deny",
+            permission_decision_reason=(
+                f"File read blocked by Enkrypt Guardrails — "
+                f"{os.path.basename(file_path)} contains: "
+                f"{', '.join(detector_names)}"
+            ),
+        )
+        output_json(output)
+        return True, 0
+
+    log_event(
+        "file_read_scan_passed",
+        {
+            "hook": hook_name,
+            "file_path": file_path,
+            "content_size": len(content),
+        },
+    )
+    return False, 0
 
 
 def main():
     """Main entry point for PreToolUse hook."""
-    # Read input from stdin
     input_data = read_hook_input()
 
     if not input_data:
@@ -69,79 +142,91 @@ def main():
     session_id = input_data.get("session_id", "")
     cwd = input_data.get("cwd", "")
 
-    # Log the hook invocation
-    log_event("hook_invoked", {
-        "hook": hook_name,
-        "tool_name": tool_name,
-        "tool_use_id": tool_use_id,
-        "session_id": session_id,
-    })
+    log_event(
+        "hook_invoked",
+        {
+            "hook": hook_name,
+            "tool_name": tool_name,
+            "tool_use_id": tool_use_id,
+            "session_id": session_id,
+        },
+    )
 
-    # Check if guardrails are enabled
     if not is_hook_enabled(hook_name):
         sys.exit(0)
 
-    # Check if this is a sensitive tool that needs extra scrutiny
     is_sensitive = is_sensitive_tool(tool_name)
 
-    # Extract text content from tool input
+    if tool_name == "Read":
+        should_exit, code = _handle_file_read(
+            tool_input, hook_name, session_id, tool_use_id, cwd
+        )
+        if should_exit:
+            sys.exit(code)
+
     text_to_check = extract_text_from_tool_input(tool_name, tool_input)
 
     if not text_to_check:
-        # No text to check, allow through
         sys.exit(0)
 
-    # Check with Enkrypt API
     should_block, violations, raw_result = check_with_enkrypt_api(text_to_check, hook_name)
 
     if should_block:
-        # Log security alert
         log_security_alert(
             "tool_input_blocked",
             {
                 "tool_name": tool_name,
                 "violations": violations,
                 "is_sensitive_tool": is_sensitive,
-                "input_preview": text_to_check[:200] if len(text_to_check) > 200 else text_to_check,
+                "input_preview": text_to_check[:200]
+                if len(text_to_check) > 200
+                else text_to_check,
             },
-            {"session_id": session_id, "tool_use_id": tool_use_id, "cwd": cwd}
+            {"session_id": session_id, "tool_use_id": tool_use_id, "cwd": cwd},
         )
 
-        # Deny the tool call using JSON output
         detector_names = [v["detector"] for v in violations]
         output = create_json_output(
             hook_event_name=hook_name,
             permission_decision="deny",
-            permission_decision_reason=f"Tool input blocked by Enkrypt Guardrails: {', '.join(detector_names)}",
+            permission_decision_reason=(
+                f"Tool input blocked by Enkrypt Guardrails: {', '.join(detector_names)}"
+            ),
         )
         output_json(output)
         sys.exit(0)
 
-    # For sensitive tools, add a warning context
     if is_sensitive:
-        log_event("sensitive_tool_allowed", {
-            "tool_name": tool_name,
-            "session_id": session_id,
-        })
+        log_event(
+            "sensitive_tool_allowed",
+            {
+                "tool_name": tool_name,
+                "session_id": session_id,
+            },
+        )
 
-        # Optionally add context for sensitive tools
         output = create_json_output(
             hook_event_name=hook_name,
-            permission_decision="ask",  # Ask user for sensitive tools
-            permission_decision_reason=f"Sensitive tool '{tool_name}' - please confirm execution",
-            additional_context=f"Note: '{tool_name}' is a sensitive tool. Proceed with caution.",
+            permission_decision="ask",
+            permission_decision_reason=(
+                f"Sensitive tool '{tool_name}' - please confirm execution"
+            ),
+            additional_context=(
+                f"Note: '{tool_name}' is a sensitive tool. Proceed with caution."
+            ),
         )
         output_json(output)
         sys.exit(0)
 
-    # Log successful check
-    log_event("hook_completed", {
-        "hook": hook_name,
-        "tool_name": tool_name,
-        "blocked": False,
-    })
+    log_event(
+        "hook_completed",
+        {
+            "hook": hook_name,
+            "tool_name": tool_name,
+            "blocked": False,
+        },
+    )
 
-    # Allow the tool call (no output needed for simple allow)
     sys.exit(0)
 
 

--- a/hooks/claude_code/hooks/session_end.py
+++ b/hooks/claude_code/hooks/session_end.py
@@ -21,8 +21,15 @@ Hook Input (via stdin):
 }
 """
 
-import sys
 import json
+import os
+import sys
+
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from enkrypt_guardrails import (
     read_hook_input,

--- a/hooks/claude_code/hooks/session_start.py
+++ b/hooks/claude_code/hooks/session_start.py
@@ -28,10 +28,16 @@ Environment Variables:
 - CLAUDE_ENV_FILE: Path to file for persisting env vars (only available in SessionStart)
 """
 
-import sys
-import os
-import json
 import datetime
+import json
+import os
+import sys
+
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from enkrypt_guardrails import (
     read_hook_input,

--- a/hooks/claude_code/hooks/setup.py
+++ b/hooks/claude_code/hooks/setup.py
@@ -33,10 +33,16 @@ Environment Variables:
 - CLAUDE_ENV_FILE: Path to file for persisting env vars (like SessionStart)
 """
 
-import sys
-import os
-import json
 import datetime
+import json
+import os
+import sys
+
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from enkrypt_guardrails import (
     read_hook_input,

--- a/hooks/claude_code/hooks/stop.py
+++ b/hooks/claude_code/hooks/stop.py
@@ -24,8 +24,15 @@ Hook Output (JSON):
 }
 """
 
-import sys
 import json
+import os
+import sys
+
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from enkrypt_guardrails import (
     read_hook_input,

--- a/hooks/claude_code/hooks/subagent_stop.py
+++ b/hooks/claude_code/hooks/subagent_stop.py
@@ -26,8 +26,15 @@ Hook Output (JSON):
 }
 """
 
-import sys
 import json
+import os
+import sys
+
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from enkrypt_guardrails import (
     read_hook_input,

--- a/hooks/claude_code/hooks/user_prompt_submit.py
+++ b/hooks/claude_code/hooks/user_prompt_submit.py
@@ -8,6 +8,11 @@ It can:
 - Block prompts (exit code 2 or JSON with decision: "block")
 - Validate prompt content
 
+In addition to scanning the prompt text, this hook extracts @filepath
+references from the prompt, reads the files from disk, and scans their
+contents through Enkrypt AI Guardrails. This ensures sensitive file data
+is caught at submission time, before the agent ever reads the file.
+
 Hook Input (via stdin):
 {
     "session_id": "abc123",
@@ -24,29 +29,69 @@ Hook Output:
 - JSON output with decision control for advanced use
 """
 
-import sys
 import json
+import os
+import re
+import sys
+from pathlib import Path
 
+os.environ.setdefault(
+    "ENKRYPT_GUARDRAILS_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "guardrails_config.json"),
+)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from enkrypt_guardrails import (
-    read_hook_input,
+    MAX_FILE_CHARS,
+    _read_file_safe,
     check_with_enkrypt_api,
-    is_hook_enabled,
-    format_blocking_error,
     create_json_output,
-    output_json,
-    output_error,
+    is_hook_enabled,
     log_event,
     log_security_alert,
+    output_json,
+    read_hook_input,
 )
+
+MAX_FILE_SCAN_CHARS = MAX_FILE_CHARS
+
+
+def _extract_file_refs(prompt, cwd=None):
+    """Extract file paths from @-references in prompt text.
+
+    Handles absolute paths (possibly with spaces) and relative paths
+    resolved against the working directory.
+    """
+    files = set()
+    parts = re.split(r"(?:^|(?<=\s))@", prompt)
+
+    for part in parts[1:]:
+        part = part.strip()
+        if not part:
+            continue
+
+        if part.startswith("/"):
+            words = part.split()
+            for i in range(len(words), 0, -1):
+                candidate = Path(" ".join(words[:i]))
+                if candidate.is_file():
+                    files.add(str(candidate.resolve()))
+                    break
+        else:
+            token = part.split()[0] if part.split() else ""
+            if not token:
+                continue
+            if cwd:
+                full = Path(cwd) / token
+                if full.is_file():
+                    files.add(str(full.resolve()))
+    return list(files)
 
 
 def main():
     """Main entry point for UserPromptSubmit hook."""
-    # Read input from stdin
     input_data = read_hook_input()
 
     if not input_data:
-        # No input, allow through
         sys.exit(0)
 
     hook_name = "UserPromptSubmit"
@@ -54,61 +99,97 @@ def main():
     session_id = input_data.get("session_id", "")
     cwd = input_data.get("cwd", "")
 
-    # Log the hook invocation
-    log_event("hook_invoked", {
-        "hook": hook_name,
-        "session_id": session_id,
-        "prompt_length": len(prompt),
-        "cwd": cwd,
-    })
+    log_event(
+        "hook_invoked",
+        {
+            "hook": hook_name,
+            "session_id": session_id,
+            "prompt_length": len(prompt),
+            "cwd": cwd,
+        },
+    )
 
-    # Check if guardrails are enabled
     if not is_hook_enabled(hook_name):
         sys.exit(0)
 
-    # Skip empty prompts
     if not prompt or not prompt.strip():
         sys.exit(0)
 
-    # Check with Enkrypt API
     should_block, violations, raw_result = check_with_enkrypt_api(prompt, hook_name)
 
+    print(
+        f"\n[Enkrypt Guardrails Response]\n{json.dumps(raw_result, indent=2)}",
+        file=sys.stderr,
+    )
+
+    all_violations = list(violations)
+    blocked_files = []
+
+    file_paths = _extract_file_refs(prompt, cwd)
+
+    for fp in sorted(file_paths):
+        content = _read_file_safe(fp, MAX_FILE_SCAN_CHARS)
+        if not content or not content.strip():
+            log_event(
+                "file_scan_skipped",
+                {
+                    "hook": hook_name,
+                    "file_path": fp,
+                    "reason": "unreadable or empty",
+                },
+            )
+            continue
+
+        file_block, file_violations, file_result = check_with_enkrypt_api(content, hook_name)
+
+        print(
+            f"\n[Enkrypt Guardrails - File: {os.path.basename(fp)}]\n"
+            f"{json.dumps(file_result, indent=2)}",
+            file=sys.stderr,
+        )
+
+        if file_violations:
+            all_violations.extend(file_violations)
+        if file_block:
+            should_block = True
+            blocked_files.append(fp)
+
     if should_block:
-        # Log security alert
         log_security_alert(
             "prompt_blocked",
             {
-                "violations": violations,
+                "violations": all_violations,
                 "prompt_preview": prompt[:200] if len(prompt) > 200 else prompt,
+                "scanned_files": sorted(file_paths),
+                "blocked_files": blocked_files,
             },
-            {"session_id": session_id, "cwd": cwd}
+            {"session_id": session_id, "cwd": cwd},
         )
 
-        # Option 1: Use exit code 2 with stderr (simpler)
-        # error_message = format_blocking_error(violations, hook_name)
-        # output_error(error_message)
-        # sys.exit(2)
+        detector_names = [v["detector"] for v in all_violations]
+        reason = f"Prompt blocked by Enkrypt Guardrails: {', '.join(detector_names)}."
+        if blocked_files:
+            file_names = ", ".join(os.path.basename(f) for f in blocked_files)
+            reason += f" Blocked file(s): {file_names}."
+        reason += " Please rephrase your request."
 
-        # Option 2: Use JSON output with decision control (more flexible)
-        detector_names = [v["detector"] for v in violations]
         output = create_json_output(
             hook_event_name=hook_name,
             decision="block",
-            reason=f"Prompt blocked by Enkrypt Guardrails: {', '.join(detector_names)}. Please rephrase your request.",
+            reason=reason,
         )
         output_json(output)
         sys.exit(0)
 
-    # Log successful check
-    log_event("hook_completed", {
-        "hook": hook_name,
-        "session_id": session_id,
-        "blocked": False,
-    })
-
-    # Success - allow the prompt
-    # Optionally add context (printed to stdout will be added to conversation)
-    # print("Additional context: Current time is ...")
+    log_event(
+        "hook_completed",
+        {
+            "hook": hook_name,
+            "session_id": session_id,
+            "blocked": False,
+            "scanned_files": sorted(file_paths),
+        },
+    )
 
     sys.exit(0)
 

--- a/hooks/cursor/README.md
+++ b/hooks/cursor/README.md
@@ -11,8 +11,10 @@ Protect your Cursor chats and MCP tool calls using Enkrypt AI guardrails.
 | `afterMCPExecution` | After an MCP tool returns | NO (audit only) | *none* |
 | `afterAgentResponse` | After the agent produces a response | NO (audit only) | *none* |
 | `stop` | When the agent completes | NO | `followup_message` (optional) |
+| `beforeReadFile` | Before the agent reads a file | **YES** | `permission`, `user_message` |
+| `afterFileEdit` | After the agent edits a file | NO (audit only) | *none* |
 
-> **Note:** Per [Cursor's hooks specification](https://cursor.com/docs/agent/hooks), only `before*` hooks support blocking. The `after*` hooks are observational—they detect violations and log security alerts but cannot prevent actions.
+> **Note:** Per [Cursor's hooks specification](https://cursor.com/docs/agent/hooks), only `before*` hooks that support blocking can deny an action. `afterFileEdit` is observational (audit/logging only), like `afterMCPExecution` and `afterAgentResponse`.
 
 ### Blocking vs Observational Hooks
 
@@ -33,12 +35,13 @@ When violations are detected in observational hooks, they are logged to `securit
 
 ### Hooks Not Supported Yet
 
-The following Cursor hooks are not yet implemented:
+The following Cursor hooks are not yet implemented here:
 
 - `beforeShellExecution` / `afterShellExecution` - Shell command control
-- `beforeReadFile` / `afterFileEdit` - File access and modification control
 - `afterAgentThought` - Agent thought tracking
 - `beforeTabFileRead` / `afterTabFileEdit` - Tab completion file operations
+
+**Implemented file hooks:** `beforeReadFile` (can block reads) and `afterFileEdit` (audit-only). Enable them in `guardrails_config.json` and register commands in `.cursor/hooks.json` (see `hooks_example.json`).
 
 ## 🚀 Quick start (project-level)
 

--- a/hooks/cursor/hooks/after_agent_response.py
+++ b/hooks/cursor/hooks/after_agent_response.py
@@ -4,18 +4,17 @@ afterAgentResponse Hook - Audits the agent's final response text using Enkrypt A
 
 Per Cursor hooks spec, this hook is observability-only (no blocking output fields supported).
 """
-import sys
 import json
-import os
+import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from enkrypt_guardrails import (  # noqa: E402
+from enkrypt_guardrails import (
     check_with_enkrypt_api,
-    log_event,
-    log_to_combined,
-    log_security_alert,
-    is_hook_enabled,
     get_hook_guardrail_name,
+    is_hook_enabled,
+    log_event,
+    log_security_alert,
+    log_to_combined,
 )
 
 HOOK_NAME = "afterAgentResponse"
@@ -23,7 +22,7 @@ HOOK_NAME = "afterAgentResponse"
 
 def main():
     try:
-        data = json.load(sys.stdin)
+        data = json.loads(sys.stdin.buffer.read().decode("utf-8-sig"))
     except json.JSONDecodeError as e:
         log_event(HOOK_NAME, {"parse_error": str(e), "error_type": "JSONDecodeError"})
         print(json.dumps({}))
@@ -35,8 +34,10 @@ def main():
     api_result = None
     if is_hook_enabled(HOOK_NAME) and text and text.strip():
         should_alert, violations, api_result = check_with_enkrypt_api(text, hook_name=HOOK_NAME)
-        # Log guardrails response to stderr (visible in Cursor hooks output)
-        print(f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}", file=sys.stderr)
+        print(
+            f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}",
+            file=sys.stderr,
+        )
         if should_alert:
             log_security_alert(
                 "agent_response_violation",
@@ -58,7 +59,6 @@ def main():
     log_event(HOOK_NAME, log_data)
     log_to_combined(HOOK_NAME, log_data)
 
-    # afterAgentResponse has no supported output fields; return empty object.
     print(json.dumps({}))
 
 

--- a/hooks/cursor/hooks/after_file_edit.py
+++ b/hooks/cursor/hooks/after_file_edit.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+afterFileEdit Hook - Audits file edits via Enkrypt AI Guardrails after the agent writes to a file.
+
+Fires after the agent edits a file. This is an audit-only hook (Cursor does not support
+blocking on afterFileEdit), but logs security alerts if written content contains policy
+violations so they can be reviewed.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from enkrypt_guardrails import (
+    check_with_enkrypt_api,
+    get_hook_guardrail_name,
+    is_hook_enabled,
+    log_event,
+    log_security_alert,
+    log_to_combined,
+)
+
+HOOK_NAME = "afterFileEdit"
+MAX_CONTENT_CHARS = 8000
+
+
+def main():
+    try:
+        data = json.loads(sys.stdin.buffer.read().decode("utf-8-sig"))
+    except json.JSONDecodeError as e:
+        log_event(HOOK_NAME, {"parse_error": str(e), "error_type": "JSONDecodeError"})
+        print(json.dumps({}))
+        return
+
+    file_path = data.get("file_path", "")
+    edits = data.get("edits", [])
+
+    if not edits:
+        print(json.dumps({}))
+        return
+
+    if not is_hook_enabled(HOOK_NAME):
+        log_event(HOOK_NAME, {"file_path": file_path, "skipped": "guardrails disabled"})
+        print(json.dumps({}))
+        return
+
+    new_content = "\n".join(
+        edit.get("new_string", "") for edit in edits if edit.get("new_string", "").strip()
+    )
+
+    if not new_content.strip():
+        print(json.dumps({}))
+        return
+
+    scan_content = new_content[:MAX_CONTENT_CHARS]
+    truncated = len(new_content) > MAX_CONTENT_CHARS
+
+    should_alert, violations, api_result = check_with_enkrypt_api(
+        scan_content, hook_name=HOOK_NAME
+    )
+
+    print(
+        f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}",
+        file=sys.stderr,
+    )
+
+    if should_alert:
+        log_security_alert(
+            "file_edit_violation",
+            {
+                "hook": HOOK_NAME,
+                "guardrail_name": get_hook_guardrail_name(HOOK_NAME),
+                "file_path": file_path,
+                "violations": violations,
+                "truncated": truncated,
+            },
+            data,
+        )
+
+    log_event(
+        HOOK_NAME,
+        {
+            "file_path": file_path,
+            "edit_count": len(edits),
+            "scan_size": len(new_content),
+            "truncated": truncated,
+            "violations": violations,
+        },
+    )
+    log_to_combined(HOOK_NAME, data)
+
+    print(json.dumps({}))
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/cursor/hooks/after_mcp_execution.py
+++ b/hooks/cursor/hooks/after_mcp_execution.py
@@ -2,20 +2,19 @@
 """
 afterMCPExecution Hook - Audits MCP results using Enkrypt AI Guardrails.
 """
-import sys
 import json
 import os
+import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from enkrypt_guardrails import (
-    check_with_enkrypt_api,
-    format_violation_message,
     analyze_mcp_result,
-    log_event,
-    log_to_combined,
-    log_security_alert,
-    is_hook_enabled,
+    check_with_enkrypt_api,
     get_hook_guardrail_name,
+    is_hook_enabled,
+    log_event,
+    log_security_alert,
+    log_to_combined,
 )
 
 HOOK_NAME = "afterMCPExecution"
@@ -23,7 +22,7 @@ HOOK_NAME = "afterMCPExecution"
 
 def main():
     try:
-        data = json.load(sys.stdin)
+        data = json.loads(sys.stdin.buffer.read().decode("utf-8-sig"))
     except json.JSONDecodeError as e:
         log_event(HOOK_NAME, {"parse_error": str(e), "error_type": "JSONDecodeError"})
         print(json.dumps({}))
@@ -33,22 +32,28 @@ def main():
     result_json = data.get("result_json", "")
     duration = data.get("duration", 0)
 
-    # Analyze the result for sensitive data patterns
     analysis = analyze_mcp_result(tool_name, result_json)
 
-    # Check with this hook's guardrails if enabled
     output_violations = []
     if is_hook_enabled(HOOK_NAME) and result_json:
-        should_alert, output_violations, api_result = check_with_enkrypt_api(result_json, hook_name=HOOK_NAME)
-        # Log guardrails response to stderr (visible in Cursor hooks output)
-        print(f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}", file=sys.stderr)
+        should_alert, output_violations, api_result = check_with_enkrypt_api(
+            result_json, hook_name=HOOK_NAME
+        )
+        print(
+            f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}",
+            file=sys.stderr,
+        )
         if should_alert:
-            log_security_alert("mcp_output_violation", {
-                "hook": HOOK_NAME,
-                "guardrail_name": get_hook_guardrail_name(HOOK_NAME),
-                "tool_name": tool_name,
-                "violations": output_violations,
-            }, data)
+            log_security_alert(
+                "mcp_output_violation",
+                {
+                    "hook": HOOK_NAME,
+                    "guardrail_name": get_hook_guardrail_name(HOOK_NAME),
+                    "tool_name": tool_name,
+                    "violations": output_violations,
+                },
+                data,
+            )
 
     log_data = {
         **data,
@@ -61,13 +66,16 @@ def main():
     log_event(HOOK_NAME, log_data)
     log_to_combined(HOOK_NAME, log_data)
 
-    # Alert if sensitive data detected via pattern matching
     if analysis["sensitive_data_hints"]:
-        log_security_alert("sensitive_data_in_mcp_result", {
-            "hook": HOOK_NAME,
-            "tool_name": tool_name,
-            "detected": analysis["sensitive_data_hints"],
-        }, data)
+        log_security_alert(
+            "sensitive_data_in_mcp_result",
+            {
+                "hook": HOOK_NAME,
+                "tool_name": tool_name,
+                "detected": analysis["sensitive_data_hints"],
+            },
+            data,
+        )
 
     print(json.dumps({}))
 

--- a/hooks/cursor/hooks/before_mcp_execution.py
+++ b/hooks/cursor/hooks/before_mcp_execution.py
@@ -2,20 +2,20 @@
 """
 beforeMCPExecution Hook - Gates MCP tools using Enkrypt AI Guardrails.
 """
-import sys
 import json
 import os
+import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from enkrypt_guardrails import (
-    check_with_enkrypt_api,
     check_mcp_tool,
+    check_with_enkrypt_api,
     format_violation_message,
-    log_event,
-    log_to_combined,
-    log_security_alert,
-    is_hook_enabled,
     get_hook_guardrail_name,
+    is_hook_enabled,
+    log_event,
+    log_security_alert,
+    log_to_combined,
 )
 
 HOOK_NAME = "beforeMCPExecution"
@@ -23,7 +23,7 @@ HOOK_NAME = "beforeMCPExecution"
 
 def main():
     try:
-        data = json.load(sys.stdin)
+        data = json.loads(sys.stdin.buffer.read().decode("utf-8-sig"))
     except json.JSONDecodeError as e:
         log_event(HOOK_NAME, {"parse_error": str(e), "error_type": "JSONDecodeError"})
         print(json.dumps({"permission": "allow"}))
@@ -32,25 +32,33 @@ def main():
     tool_name = data.get("tool_name", "")
     tool_input = data.get("tool_input", "")
 
-    # First check MCP tool patterns
     permission, user_message, agent_message = check_mcp_tool(tool_name, tool_input)
 
-    # If allowed and this hook's guardrails are enabled, scan input with Enkrypt API
     if permission == "allow" and tool_input and is_hook_enabled(HOOK_NAME):
-        should_block, violations, api_result = check_with_enkrypt_api(tool_input, hook_name=HOOK_NAME)
-        # Log guardrails response to stderr (visible in Cursor hooks output)
-        print(f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}", file=sys.stderr)
+        should_block, violations, api_result = check_with_enkrypt_api(
+            tool_input, hook_name=HOOK_NAME
+        )
+        print(
+            f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}",
+            file=sys.stderr,
+        )
         if should_block:
             violation_message = format_violation_message(violations, hook_name=HOOK_NAME)
             permission = "deny"
             user_message = f"⛔ MCP tool input blocked by Enkrypt AI:\n\n{violation_message}"
-            agent_message = "The MCP tool input contains policy violations and has been blocked."
-            log_security_alert("mcp_input_blocked", {
-                "hook": HOOK_NAME,
-                "guardrail_name": get_hook_guardrail_name(HOOK_NAME),
-                "tool_name": tool_name,
-                "violations": violations,
-            }, data)
+            agent_message = (
+                "The MCP tool input contains policy violations and has been blocked."
+            )
+            log_security_alert(
+                "mcp_input_blocked",
+                {
+                    "hook": HOOK_NAME,
+                    "guardrail_name": get_hook_guardrail_name(HOOK_NAME),
+                    "tool_name": tool_name,
+                    "violations": violations,
+                },
+                data,
+            )
 
     result = {"permission": permission}
     if user_message:

--- a/hooks/cursor/hooks/before_read_file.py
+++ b/hooks/cursor/hooks/before_read_file.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+beforeReadFile Hook - Scans file contents via Enkrypt AI Guardrails before the agent reads the file.
+
+Fires before the agent reads a file. Can block the read if the file contents contain
+policy violations (PII, secrets, injection payloads, etc.), preventing sensitive data
+from being sent to the model.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from enkrypt_guardrails import (
+    check_with_enkrypt_api,
+    format_violation_message,
+    get_hook_guardrail_name,
+    is_hook_enabled,
+    log_event,
+    log_security_alert,
+    log_to_combined,
+)
+
+HOOK_NAME = "beforeReadFile"
+MAX_CONTENT_CHARS = 8000
+
+
+def main():
+    try:
+        data = json.loads(sys.stdin.buffer.read().decode("utf-8-sig"))
+    except json.JSONDecodeError as e:
+        log_event(HOOK_NAME, {"parse_error": str(e), "error_type": "JSONDecodeError"})
+        print(json.dumps({"permission": "allow"}))
+        return
+
+    file_path = data.get("file_path", "")
+    content = data.get("content", "")
+
+    if not content.strip():
+        print(json.dumps({"permission": "allow"}))
+        return
+
+    if not is_hook_enabled(HOOK_NAME):
+        log_event(HOOK_NAME, {"file_path": file_path, "skipped": "guardrails disabled"})
+        print(json.dumps({"permission": "allow"}))
+        return
+
+    scan_content = content[:MAX_CONTENT_CHARS]
+    truncated = len(content) > MAX_CONTENT_CHARS
+
+    should_block, violations, api_result = check_with_enkrypt_api(
+        scan_content, hook_name=HOOK_NAME
+    )
+
+    print(
+        f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}",
+        file=sys.stderr,
+    )
+
+    if should_block:
+        violation_message = format_violation_message(violations, hook_name=HOOK_NAME)
+        log_security_alert(
+            "file_read_blocked",
+            {
+                "hook": HOOK_NAME,
+                "guardrail_name": get_hook_guardrail_name(HOOK_NAME),
+                "file_path": file_path,
+                "violations": violations,
+                "truncated": truncated,
+            },
+            data,
+        )
+        result = {
+            "permission": "deny",
+            "user_message": (
+                f"⛔ File read blocked by Enkrypt AI Guardrails:\n\n{violation_message}"
+            ),
+        }
+    else:
+        result = {"permission": "allow"}
+
+    log_event(
+        HOOK_NAME,
+        {
+            "file_path": file_path,
+            "content_size": len(content),
+            "truncated": truncated,
+            "violations": violations,
+        },
+        result,
+    )
+    log_to_combined(HOOK_NAME, data, result)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/cursor/hooks/before_submit_prompt.py
+++ b/hooks/cursor/hooks/before_submit_prompt.py
@@ -1,67 +1,186 @@
 #!/usr/bin/env python
 """
-beforeSubmitPrompt Hook - Validates prompts using Enkrypt AI Guardrails.
+beforeSubmitPrompt Hook - Validates prompts AND attached file contents
+using Enkrypt AI Guardrails.
+
+Scans both the user's prompt text and the contents of any files referenced
+via @filepath patterns or the attachments array before they reach the LLM.
+This is critical because Cursor resolves user @-attached files internally
+and sends their contents directly to the model without triggering the
+beforeReadFile hook.
 """
-import sys
 import json
 import os
+import re
+import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from enkrypt_guardrails import (
     check_with_enkrypt_api,
     format_violation_message,
-    log_event,
-    log_to_combined,
-    log_security_alert,
-    is_hook_enabled,
     get_hook_guardrail_name,
+    is_hook_enabled,
+    log_event,
+    log_security_alert,
+    log_to_combined,
 )
 
 HOOK_NAME = "beforeSubmitPrompt"
+MAX_FILE_CHARS = 8000
+
+
+def _extract_file_refs(prompt, workspace_roots):
+    """Extract file paths from @-references in prompt text.
+
+    Handles both absolute paths (possibly containing spaces) and
+    relative paths resolved against workspace_roots.
+    """
+    files = []
+    parts = re.split(r"(?:^|(?<=\s))@", prompt)
+
+    for part in parts[1:]:
+        part = part.strip()
+        if not part:
+            continue
+
+        if part.startswith("/"):
+            words = part.split()
+            for end in range(len(words), 0, -1):
+                candidate = " ".join(words[:end])
+                if os.path.isfile(candidate):
+                    files.append(candidate)
+                    break
+        else:
+            token = part.split()[0] if part.split() else ""
+            if not token:
+                continue
+            for root in workspace_roots or []:
+                full = os.path.join(root, token)
+                if os.path.isfile(full):
+                    files.append(full)
+                    break
+
+    return files
+
+
+def _read_file_safe(path, max_chars=MAX_FILE_CHARS):
+    """Read file contents as text, returning None for binary/unreadable files."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="strict") as f:
+            return f.read(max_chars)
+    except (UnicodeDecodeError, ValueError):
+        try:
+            with open(path, "r", encoding="latin-1") as f:
+                return f.read(max_chars)
+        except Exception:
+            return None
+    except (OSError, IOError):
+        return None
 
 
 def main():
     try:
-        data = json.load(sys.stdin)
+        data = json.loads(sys.stdin.buffer.read().decode("utf-8-sig"))
     except json.JSONDecodeError as e:
         log_event(HOOK_NAME, {"parse_error": str(e), "error_type": "JSONDecodeError"})
         print(json.dumps({"continue": True}))
         return
 
     prompt = data.get("prompt", "")
+    attachments = data.get("attachments", [])
+    workspace_roots = data.get("workspace_roots", [])
 
     if not prompt.strip():
         print(json.dumps({"continue": True}))
         return
 
-    # Check if this hook's guardrails are enabled
     if not is_hook_enabled(HOOK_NAME):
         log_event(HOOK_NAME, {**data, "skipped": "guardrails disabled"})
         print(json.dumps({"continue": True}))
         return
 
-    # Check with Enkrypt AI API
-    should_block, violations, api_result = check_with_enkrypt_api(prompt, hook_name=HOOK_NAME)
+    should_block, violations, api_result = check_with_enkrypt_api(
+        prompt, hook_name=HOOK_NAME
+    )
+    print(
+        f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}",
+        file=sys.stderr,
+    )
 
-    # Log guardrails response to stderr (visible in Cursor hooks output)
-    print(f"\n[Enkrypt Guardrails Response]\n{json.dumps(api_result, indent=2)}", file=sys.stderr)
+    all_violations = list(violations)
+    blocked_files = []
+
+    file_paths = set()
+    for att in attachments:
+        fp = att.get("file_path", "")
+        if fp and att.get("type") == "file":
+            file_paths.add(fp)
+
+    for fp in _extract_file_refs(prompt, workspace_roots):
+        file_paths.add(fp)
+
+    for fp in sorted(file_paths):
+        content = _read_file_safe(fp)
+        if not content or not content.strip():
+            continue
+
+        file_should_block, file_violations, file_api_result = check_with_enkrypt_api(
+            content, hook_name=HOOK_NAME
+        )
+        print(
+            f"\n[Enkrypt Guardrails - File: {os.path.basename(fp)}]\n"
+            f"{json.dumps(file_api_result, indent=2)}",
+            file=sys.stderr,
+        )
+
+        if file_violations:
+            all_violations.extend(file_violations)
+        if file_should_block:
+            should_block = True
+            blocked_files.append(fp)
 
     if should_block:
-        violation_message = format_violation_message(violations, hook_name=HOOK_NAME)
+        violation_message = format_violation_message(
+            all_violations, hook_name=HOOK_NAME
+        )
+        if blocked_files:
+            file_names = ", ".join(os.path.basename(f) for f in blocked_files)
+            violation_message += f"\n\nBlocked file(s): {file_names}"
+
         result = {
             "continue": False,
-            "user_message": f"⛔ Prompt blocked by Enkrypt AI Guardrails:\n\n{violation_message}"
+            "user_message": (
+                f"⛔ Prompt blocked by Enkrypt AI Guardrails:\n\n{violation_message}"
+            ),
         }
-        log_security_alert("prompt_blocked", {
-            "hook": HOOK_NAME,
-            "guardrail_name": get_hook_guardrail_name(HOOK_NAME),
-            "violations": violations,
-            "prompt_preview": prompt[:200] + "..." if len(prompt) > 200 else prompt,
-        }, data)
+        log_security_alert(
+            "prompt_blocked",
+            {
+                "hook": HOOK_NAME,
+                "guardrail_name": get_hook_guardrail_name(HOOK_NAME),
+                "violations": all_violations,
+                "prompt_preview": (
+                    prompt[:200] + "..." if len(prompt) > 200 else prompt
+                ),
+                "scanned_files": sorted(file_paths),
+                "blocked_files": blocked_files,
+            },
+            data,
+        )
     else:
         result = {"continue": True}
 
-    log_event(HOOK_NAME, {**data, "api_result": api_result, "violations": violations}, result)
+    log_event(
+        HOOK_NAME,
+        {
+            **data,
+            "api_result": api_result,
+            "violations": all_violations,
+            "scanned_files": sorted(file_paths),
+            "blocked_files": blocked_files,
+        },
+        result,
+    )
     log_to_combined(HOOK_NAME, data, result)
 
     print(json.dumps(result))

--- a/hooks/cursor/hooks/diagnostics.py
+++ b/hooks/cursor/hooks/diagnostics.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Cursor hooks diagnostic — determines how Cursor actually passes event data on Windows."""
+import json
+import os
+import sys
+import threading
+from pathlib import Path
+
+LOG = Path.home() / "cursor" / "hooks_logs" / "diagnostic.json"
+LOG.parent.mkdir(parents=True, exist_ok=True)
+
+out: dict = {
+    "sys_argv": sys.argv,
+    "env_vars": {
+        k: v
+        for k, v in os.environ.items()
+        if "cursor" in k.lower() or "hook" in k.lower()
+    },
+    "stdin_result": None,
+    "stdin_empty": None,
+}
+
+stdin_data: list = []
+
+
+def _read_stdin() -> None:
+    try:
+        stdin_data.append(sys.stdin.buffer.read())
+    except Exception as exc:
+        stdin_data.append(repr(exc).encode())
+
+
+t = threading.Thread(target=_read_stdin, daemon=True)
+t.start()
+t.join(timeout=3.0)
+
+if stdin_data:
+    raw = stdin_data[0]
+    out["stdin_result"] = raw.decode("utf-8", errors="replace")
+    out["stdin_empty"] = raw == b""
+else:
+    out["stdin_result"] = "timeout_no_data"
+    out["stdin_empty"] = True
+
+LOG.write_text(json.dumps(out, indent=2, default=str))
+
+print(json.dumps({"continue": True}))

--- a/hooks/cursor/hooks/enkrypt_guardrails.py
+++ b/hooks/cursor/hooks/enkrypt_guardrails.py
@@ -268,7 +268,14 @@ def validate_config(config: dict) -> List[str]:
             errors.append(f"enkrypt_api.fail_silently must be a boolean, got: {type(fail_silently).__name__}")
 
     # Validate hook policies
-    valid_hooks = ["beforeSubmitPrompt", "beforeMCPExecution", "afterMCPExecution", "afterAgentResponse"]
+    valid_hooks = [
+        "beforeSubmitPrompt",
+        "beforeMCPExecution",
+        "afterMCPExecution",
+        "afterAgentResponse",
+        "beforeReadFile",
+        "afterFileEdit",
+    ]
     for hook_name in valid_hooks:
         policy = config.get(hook_name, {})
         if policy:
@@ -341,6 +348,8 @@ HOOK_POLICIES = {
     "beforeMCPExecution": CONFIG.get("beforeMCPExecution", {}),
     "afterMCPExecution": CONFIG.get("afterMCPExecution", {}),
     "afterAgentResponse": CONFIG.get("afterAgentResponse", {}),
+    "beforeReadFile": CONFIG.get("beforeReadFile", {}),
+    "afterFileEdit": CONFIG.get("afterFileEdit", {}),
 }
 
 
@@ -698,6 +707,8 @@ def get_source_event(hook_name: str) -> str:
         "beforeMCPExecution": "pre-tool",
         "afterMCPExecution": "post-tool",
         "afterAgentResponse": "post-response",
+        "beforeReadFile": "pre-file-read",
+        "afterFileEdit": "post-file-edit",
     }
     return event_mapping.get(hook_name, hook_name)
 
@@ -1043,6 +1054,8 @@ def reload_config():
         "beforeMCPExecution": CONFIG.get("beforeMCPExecution", {}),
         "afterMCPExecution": CONFIG.get("afterMCPExecution", {}),
         "afterAgentResponse": CONFIG.get("afterAgentResponse", {}),
+        "beforeReadFile": CONFIG.get("beforeReadFile", {}),
+        "afterFileEdit": CONFIG.get("afterFileEdit", {}),
     }
     SENSITIVE_MCP_TOOLS = CONFIG.get("sensitive_mcp_tools", [])
 

--- a/hooks/cursor/hooks/guardrails_config_example.json
+++ b/hooks/cursor/hooks/guardrails_config_example.json
@@ -49,6 +49,28 @@
       "nsfw"
     ]
   },
+  "beforeReadFile": {
+    "enabled": false,
+    "guardrail_name": "Sample Airline Guardrail",
+    "block": [
+      "injection_attack",
+      "pii",
+      "keyword_detector",
+      "policy_violation",
+      "nsfw",
+      "toxicity"
+    ]
+  },
+  "afterFileEdit": {
+    "enabled": false,
+    "guardrail_name": "Sample Airline Guardrail",
+    "block": [
+      "pii",
+      "toxicity",
+      "nsfw",
+      "policy_violation"
+    ]
+  },
   "sensitive_mcp_tools": [
     "execute_sql",
     "delete_",

--- a/hooks/cursor/hooks/stop.py
+++ b/hooks/cursor/hooks/stop.py
@@ -2,22 +2,21 @@
 """
 stop Hook - Handles agent loop completion.
 """
-import sys
 import json
-import os
+import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from enkrypt_guardrails import (
+    LOG_DIR,
     get_timestamp,
     log_event,
     log_to_combined,
-    LOG_DIR
 )
 
 
 def main():
     try:
-        data = json.load(sys.stdin)
+        data = json.loads(sys.stdin.buffer.read().decode("utf-8-sig"))
     except json.JSONDecodeError as e:
         log_event("stop", {"parse_error": str(e), "error_type": "JSONDecodeError"})
         print(json.dumps({}))
@@ -26,7 +25,6 @@ def main():
     status = data.get("status", "completed")
     loop_count = data.get("loop_count", 0)
 
-    # Generate session summary
     summary = {
         "conversation_id": data.get("conversation_id"),
         "generation_id": data.get("generation_id"),
@@ -40,7 +38,6 @@ def main():
     log_event("stop", {**data, "summary": summary})
     log_to_combined("stop", data)
 
-    # Write session summary
     summary_file = LOG_DIR / "session_summaries.jsonl"
     with open(summary_file, "a", encoding="utf-8") as f:
         f.write(json.dumps(summary) + "\n")

--- a/hooks/cursor/hooks/tests/test_enkrypt_guardrails.py
+++ b/hooks/cursor/hooks/tests/test_enkrypt_guardrails.py
@@ -607,5 +607,15 @@ class TestDynamicReload(unittest.TestCase):
         self.assertTrue(callable(flush_logs))
 
 
+class TestGetSourceEvent(unittest.TestCase):
+    """API header mapping for Cursor hooks."""
+
+    def test_file_hook_events(self):
+        from enkrypt_guardrails import get_source_event
+
+        self.assertEqual(get_source_event("beforeReadFile"), "pre-file-read")
+        self.assertEqual(get_source_event("afterFileEdit"), "post-file-edit")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hooks/cursor/hooks_example.json
+++ b/hooks/cursor/hooks_example.json
@@ -21,6 +21,16 @@
         "command": "hooks\\cursor\\venv\\Scripts\\python.exe hooks\\cursor\\hooks\\after_agent_response.py"
       }
     ],
+    "beforeReadFile": [
+      {
+        "command": "hooks\\cursor\\venv\\Scripts\\python.exe hooks\\cursor\\hooks\\before_read_file.py"
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "hooks\\cursor\\venv\\Scripts\\python.exe hooks\\cursor\\hooks\\after_file_edit.py"
+      }
+    ],
     "stop": [
       {
         "command": "hooks\\cursor\\venv\\Scripts\\python.exe hooks\\cursor\\hooks\\stop.py"


### PR DESCRIPTION


### Add file-content scanning to Cursor and Claude Code guardrail hooks

### Why

Previously, hooks mostly scanned **prompt text** and **tool/MCP strings** (e.g. paths in tool input), not **actual file contents**. Sensitive data in files referenced with `@` in the prompt, or read via the agent’s Read tool, could bypass guardrails.

### What changed (this repository)

**Cursor (`hooks/cursor/hooks/`)**

- **`before_submit_prompt.py`**: Parses `@filepath`-style references and `attachments`, reads matching files from disk (up to 8k chars each), and runs each through the Enkrypt API. Blocks submission when the prompt or any scanned file violates policy.
- **`enkrypt_guardrails.py`**: Extended hook policy and API event mapping for **`beforeReadFile`** and **`afterFileEdit`** (`get_source_event`, `HOOK_POLICIES`, validation, reload).
- **New scripts**: **`before_read_file.py`** (can deny reads), **`after_file_edit.py`** (audit-only; Cursor cannot block after edit), **`diagnostics.py`** (stdin/env diagnostic helper).
- **`after_agent_response.py`**, **`after_mcp_execution.py`**, **`before_mcp_execution.py`**, **`stop.py`**: Aligned with the newer behavior (e.g. utf-8-sig stdin, stderr logging where applicable; `stop` writes session summaries under `LOG_DIR`).
- **Docs / examples**: [`hooks/cursor/README.md`](hooks/cursor/README.md), [`hooks/cursor/hooks/guardrails_config_example.json`](hooks/cursor/hooks/guardrails_config_example.json), [`hooks/cursor/hooks_example.json`](hooks/cursor/hooks_example.json) updated for the new hooks and config keys.
- **Tests**: [`hooks/cursor/hooks/tests/test_enkrypt_guardrails.py`](hooks/cursor/hooks/tests/test_enkrypt_guardrails.py) — e.g. `get_source_event` coverage for file hooks.

**Claude Code (`hooks/claude_code/hooks/`)**

- **`pre_tool_use.py`**: For **`Read`**, reads the target file from disk, scans content via the API, and denies the tool call on violation before the usual tool-input scan.
- **`user_prompt_submit.py`**: Scans the prompt text, then parses `@` file references, reads those files, and scans contents (same idea as Cursor’s `before_submit_prompt`).
- **`enkrypt_guardrails.py`**: Added **`_read_file_safe`**, **`MAX_FILE_CHARS`**, and **`extract_file_content_for_read`** (equivalent to what lived under the wheel’s provider module — implemented here in the shared module, not as a separate installed package).
- **Other hook entrypoints** (`session_start`, `notification`, `post_tool_use`, etc.): Shared bootstrap so **`ENKRYPT_GUARDRAILS_CONFIG`** points at `guardrails_config.json` next to the script before importing `enkrypt_guardrails`.

### Known limitations / things to watch

- Content is **truncated to 8000 characters** before the API call; very large files are only partially scanned.
- **`@` parsing** is heuristic; it can misfire on emails or other `@` usage in free text.
- **Cursor `beforeReadFile`** applies to agent-initiated reads; **user-attached `@` files** are why **`before_submit_prompt`** was extended.
- **`afterFileEdit`** is **audit-only** per Cursor’s hook model.
- **`_read_file_safe`** returns `None` for non-text / unreadable files → **no scan** for those.
- **`hooks/claude_code/hooks/tests/test_enkrypt_guardrails.py`** still requires **pytest** if you run that test module locally.
