### PR TITLE
fix(auth): honor X-Enkrypt-MCP-Gateway-Version from the request (v2.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 All notable changes to the Enkrypt Secure MCP Gateway project will be documented in this file.
 
-## [Unreleased]
+## [v2.2.2]
+
+### Fixed
+
+- **`X-Enkrypt-MCP-Gateway-Version` is now honored on the request.**  Enkrypt
+  cloud looks a gateway up by `(gateway_saved_name, gateway_version)`, but the
+  gateway only read the name from the client and always sent the version from
+  `plugins.auth.config.gateway_version` (default `"v1"`).  Gateways registered
+  under any other version were unreachable from a header-routed deployment —
+  `get-gateway-config` returned `404 MCP gateway not found` on every request.
+
+  The version now resolves like the name: pinned `auth.config` value wins,
+  otherwise the request header, otherwise `"v1"`.  Configs that set it are
+  unaffected; configs that omit it gain per-request routing.
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1499,6 +1499,17 @@ Set `enkrypt_log_level: "DEBUG"` in config for verbose logging.
 
 ---
 
+## ✍️ Code & Docs Conventions
+
+- **Comments: minimal.** One line, only where the code genuinely isn't
+  self-explanatory. No multi-line comment blocks, no rationale essays, no
+  restating what the next line does. Same for docstrings — one line unless the
+  function's contract truly needs more.
+- **CHANGELOG: high-level only.** What broke / what changed and why it matters
+  to an operator. No file-by-file lists, no threading details, no test names.
+- These override the older verbose style still visible in parts of this repo;
+  don't take existing long comment blocks as a template for new code.
+
 ## 🏆 Best Practices
 
 1. **Always use API keys**: Don't bypass authentication

--- a/README.md
+++ b/README.md
@@ -3332,7 +3332,7 @@ Setting `plugins.auth.provider` to `"enkrypt"` switches the gateway from local `
 | Key | Required | Default | What it does |
 |---|---|---|---|
 | `gateway_name` | yes, unless clients send the `X-Enkrypt-MCP-Gateway` header | — | The `saved_name` of the gateway you created in the Enkrypt console (the `saved_name` field returned by `/mcp-gateway/add-gateway`). Sent to the cloud as `X-Enkrypt-MCP-Gateway`. |
-| `gateway_version` | no | `"v1"` | Sent as `X-Enkrypt-MCP-Gateway-Version`. Config-only — there is no per-request header for it. |
+| `gateway_version` | no | the `X-Enkrypt-MCP-Gateway-Version` header, else `"v1"` | Sent as `X-Enkrypt-MCP-Gateway-Version`. Setting it here **pins** the version for every request on this process and overrides the client header; leave it out to let each client pick its own. |
 | `project_name` | no | inferred by the cloud from the apikey; `"default"` when the apikey isn't a project apikey | Sent as `X-Enkrypt-Project`, and **only when set** — leave it out to let the cloud infer. Config-only. |
 | `apikey` | no | `enkrypt_config.api_key` | Boot-time fallback used only when an MCP client connects without its own `apikey` header. Note the spelling: under `plugins.auth.config` the key is `apikey`, not `api_key`. |
 | `base_url` | no | `enkrypt_config.base_url`, else `https://api.enkryptai.com` | Trailing slash is stripped. |
@@ -3348,14 +3348,15 @@ Setting `plugins.auth.provider` to `"enkrypt"` switches the gateway from local `
 |---|---|---|
 | `apikey` | yes | Your Enkrypt cloud apikey. It is read per request and forwarded as the outbound `apikey` to Enkrypt cloud, so each connected client can carry its own key and get its own config. |
 | `X-Enkrypt-MCP-Gateway` | only when `plugins.auth.config.gateway_name` is **not** set | Selects which cloud gateway config to fetch, per request. If `gateway_name` **is** set in the config, the config value wins and a differing header is ignored (an `INFO` line records the override). |
+| `X-Enkrypt-MCP-Gateway-Version` | no | The gateway's registered version. Cloud lookup is keyed on `(saved_name, version)`, so a gateway registered as e.g. `1` rather than `v1` is only reachable when the client sends this. Same precedence as above: a `gateway_version` pinned in `plugins.auth.config` wins and the header is ignored (logged); otherwise the header is used; otherwise `v1`. |
 
 If neither the config nor the header supplies a gateway name, authentication fails with `Missing X-Enkrypt-MCP-Gateway header and no gateway_name in auth.config`.
 
-There are no per-request equivalents of `gateway_version` / `project_name` — both come from the config only.
+`project_name` has no per-request equivalent — it comes from the config only.
 
 > **⚠️ Don't send `ENKRYPT_GATEWAY_KEY` in cloud mode.** For backward compatibility the gateway prefers an `ENKRYPT_GATEWAY_KEY` header over `apikey` when both are present, then forwards it to the cloud. A leftover `ENKRYPT_GATEWAY_KEY` from an old `local_apikey` client config will therefore shadow your correct cloud apikey and produce 401s. Send only the headers your active provider needs (see the per-provider header table in [docs/auth-providers.md](./docs/auth-providers.md#header-contract-per-provider)).
 
-> **Note on stdio installs.** Headers only exist on the streamable-HTTP transport. When the MCP client spawns the gateway over stdio, credentials come from env vars (`ENKRYPT_APIKEY` for the cloud provider) and there is **no** env-var equivalent for the gateway name — so stdio deployments must set `plugins.auth.config.gateway_name` in the config file.
+> **Note on stdio installs.** Headers only exist on the streamable-HTTP transport. When the MCP client spawns the gateway over stdio, credentials come from env vars (`ENKRYPT_APIKEY` for the cloud provider) and there is **no** env-var equivalent for the gateway name or version — so stdio deployments must set `plugins.auth.config.gateway_name` (and `gateway_version`, if the gateway isn't `v1`) in the config file.
 
 #### 7.1.3 Headers the gateway sends to Enkrypt cloud
 
@@ -3365,7 +3366,7 @@ There are no per-request equivalents of `gateway_version` / `project_name` — b
 |---|---|
 | `apikey` | The calling client's apikey, falling back to `plugins.auth.config.apikey` / `enkrypt_config.api_key` |
 | `X-Enkrypt-MCP-Gateway` | `plugins.auth.config.gateway_name`, falling back to the inbound `X-Enkrypt-MCP-Gateway` header |
-| `X-Enkrypt-MCP-Gateway-Version` | `plugins.auth.config.gateway_version` (default `v1`) |
+| `X-Enkrypt-MCP-Gateway-Version` | `plugins.auth.config.gateway_version` if pinned, else the inbound `X-Enkrypt-MCP-Gateway-Version` header, else `v1` |
 | `X-Enkrypt-Project` | `plugins.auth.config.project_name` — omitted entirely when unset |
 
 Every call is logged with the apikey masked, so you can confirm which gateway/project/key a request actually used:
@@ -3378,9 +3379,9 @@ Match the last 4 characters against the key you expect — a mismatch means the 
 
 #### 7.1.4 One gateway process, several cloud gateways
 
-Because `gateway_name` may arrive per request, a single gateway deployment can front more than one cloud gateway config: leave `plugins.auth.config.gateway_name` **unset** and have each MCP client send its own `X-Enkrypt-MCP-Gateway` header alongside its `apikey`. Cloud responses are cached in-process under a SHA-256 hash of `apikey | gateway_name | gateway_version | project_name`, so tenants never cross-contaminate each other's config. See [§4.4.2](#442-modify-your-mcp-client-config-to-use-the-gateway) for the client-side JSON.
+Because `gateway_name` may arrive per request, a single gateway deployment can front more than one cloud gateway config: leave `plugins.auth.config.gateway_name` **unset** and have each MCP client send its own `X-Enkrypt-MCP-Gateway` header alongside its `apikey`. Clients whose gateway is registered under a version other than `v1` send `X-Enkrypt-MCP-Gateway-Version` alongside it. Cloud responses are cached in-process under a SHA-256 hash of `apikey | gateway_name | gateway_version | project_name`, so tenants — and two versions of the same gateway — never cross-contaminate each other's config. See [§4.4.2](#442-modify-your-mcp-client-config-to-use-the-gateway) for the client-side JSON.
 
-Note the trade-off: `gateway_version` and `project_name` stay process-wide, so all clients on that process share them. Pin `gateway_name` in the config instead whenever one deployment serves exactly one cloud gateway — it is the safer default, since the effective gateway is then fixed server-side and client-supplied headers can no longer steer it. (Enkrypt cloud still authorizes every apikey against the gateway it names, so the header is not an authorization bypass either way.)
+Note the trade-off: `project_name` stays process-wide, so all clients on that process share it. Pin `gateway_name` (and `gateway_version`) in the config instead whenever one deployment serves exactly one cloud gateway — it is the safer default, since the effective gateway is then fixed server-side and client-supplied headers can no longer steer it. (Enkrypt cloud still authorizes every apikey against the gateway it names, so the header is not an authorization bypass either way.)
 
 #### 7.1.5 Failure handling
 

--- a/docs/auth-providers.md
+++ b/docs/auth-providers.md
@@ -37,11 +37,39 @@ clients that don't supply their own.
 | Key | Required | Default | Notes |
 | --- | --- | --- | --- |
 | `gateway_name` | yes, unless clients send the header | — | Matches the `saved_name` field on the cloud's `add-gateway` response. Sent as the `X-Enkrypt-MCP-Gateway` request header on the outbound cloud call. May be omitted here and supplied per request by the MCP client's own `X-Enkrypt-MCP-Gateway` header; when both are present this config value wins and the header is ignored (logged at INFO). |
-| `gateway_version` | no | `"v1"` | Sent as `X-Enkrypt-MCP-Gateway-Version`. |
+| `gateway_version` | no | the request's `X-Enkrypt-MCP-Gateway-Version` header, else `"v1"` | Sent as `X-Enkrypt-MCP-Gateway-Version` on the outbound cloud call. Setting it here pins the version process-wide and overrides the client header (logged at INFO); omit it so header-routed deployments can serve gateways registered under different versions. |
 | `project_name` | no | inferred from apikey ownership; defaults to `"default"` if the apikey isn't a project apikey | Sent as `X-Enkrypt-Project`. |
 | `apikey` | no | — | Boot-time fallback used when an MCP client connects without its own apikey header. |
 | `base_url` | no | `https://api.enkryptai.com` | Trailing slash stripped. |
 | `cache_ttl_seconds` | no | 600 | In-process cache TTL for cloud responses. |
+
+### Gateway identity resolution (name + version)
+
+The cloud looks a gateway up by the pair `(gateway_saved_name,
+gateway_version)`. Both halves resolve with the same precedence, first
+match wins:
+
+1. `auth.config.<gateway_name|gateway_version>` — pinned by the operator,
+   always beats a client header (a differing header is logged at INFO and
+   dropped).
+2. The request header (`X-Enkrypt-MCP-Gateway` /
+   `X-Enkrypt-MCP-Gateway-Version`).
+3. Default — none for the name (auth fails with
+   `AuthStatus.INVALID_CREDENTIALS`), `"v1"` for the version.
+
+Pinning the version is only right when the process serves a single cloud
+gateway. A header-routed deployment (`gateway_name` unset, several tenants
+on one process) must leave `gateway_version` unset, because the version is
+part of the lookup key: with a pinned `v1`, any gateway registered as `1`
+or `v2` returns
+
+```json
+{"code": 404, "error": "Resource not found", "message": "MCP gateway not found"}
+```
+
+which surfaces to the MCP client as `AuthStatus.ERROR` on every call. The
+in-process cache keys on the resolved version too, so two versions of the
+same gateway never share an entry.
 
 ### Removed keys (hard fail)
 
@@ -181,7 +209,7 @@ cloud and get a 401 back.
 | Provider | Required headers | Optional headers |
 | --- | --- | --- |
 | `local_apikey` | `ENKRYPT_GATEWAY_KEY` | `project_id`, `user_id` |
-| `enkrypt` | `apikey` | `X-Enkrypt-MCP-Gateway` — required only when `auth.config.gateway_name` is unset; ignored when it is set |
+| `enkrypt` | `apikey` | `X-Enkrypt-MCP-Gateway` — required only when `auth.config.gateway_name` is unset; ignored when it is set. `X-Enkrypt-MCP-Gateway-Version` — used when `auth.config.gateway_version` is unset (defaults to `v1`); ignored when it is set |
 
 When a request arrives, `AuthConfigManager.extract_credentials()` reads
 both shapes (this is for backwards compatibility); the active provider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "secure-mcp-gateway"
-version = "2.2.1"
+version = "2.2.2"
 description = "Enkrypt AI Secure MCP Gateway — authentication, guardrails, caching, and observability for Model Context Protocol servers."
 readme = "README_PYPI.md"
 requires-python = ">=3.10"

--- a/src/secure_mcp_gateway/gateway.py
+++ b/src/secure_mcp_gateway/gateway.py
@@ -273,12 +273,16 @@ def get_gateway_credentials(ctx: Context):
 
 # Read from local MCP config file
 async def get_local_mcp_config(
-    gateway_key, project_id=None, user_id=None, gateway_name=None
+    gateway_key, project_id=None, user_id=None, gateway_name=None, gateway_version=None
 ):
     """Wrapper for getting local MCP config using the auth manager."""
     auth_manager = get_auth_config_manager()
     return await auth_manager.get_local_mcp_config(
-        gateway_key, project_id, user_id, gateway_name=gateway_name
+        gateway_key,
+        project_id,
+        user_id,
+        gateway_name=gateway_name,
+        gateway_version=gateway_version,
     )
 
 
@@ -539,11 +543,16 @@ async def enkrypt_discover_all_tools(ctx: Context, server_name: str = None):
     project_id = creds.get("project_id")
     user_id = creds.get("user_id")
     gateway_name = creds.get("gateway_name")
+    gateway_version = creds.get("gateway_version")
 
     # Get mcp_config_id from local config
     auth_manager = get_auth_config_manager()
     local_config = await auth_manager.get_local_mcp_config(
-        gateway_key, project_id, user_id, gateway_name=gateway_name
+        gateway_key,
+        project_id,
+        user_id,
+        gateway_name=gateway_name,
+        gateway_version=gateway_version,
     )
     mcp_config_id = (
         local_config.get("mcp_config_id", "not_provided")

--- a/src/secure_mcp_gateway/plugins/auth/base.py
+++ b/src/secure_mcp_gateway/plugins/auth/base.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Protocol
+from typing import Any, Protocol
 
 # ============================================================================
 # Enums
@@ -47,24 +47,25 @@ class AuthCredentials:
     """
 
     # Primary credentials
-    api_key: Optional[str] = None
-    gateway_key: Optional[str] = None
-    gateway_name: Optional[str] = None
-    project_id: Optional[str] = None
-    user_id: Optional[str] = None
+    api_key: str | None = None
+    gateway_key: str | None = None
+    gateway_name: str | None = None
+    gateway_version: str | None = None
+    project_id: str | None = None
+    user_id: str | None = None
 
     # OAuth/JWT
-    access_token: Optional[str] = None
-    refresh_token: Optional[str] = None
-    id_token: Optional[str] = None
+    access_token: str | None = None
+    refresh_token: str | None = None
+    id_token: str | None = None
 
     # Basic auth
-    username: Optional[str] = None
-    password: Optional[str] = None
+    username: str | None = None
+    password: str | None = None
 
     # Additional metadata
-    headers: Dict[str, str] = field(default_factory=dict)
-    context: Dict[str, Any] = field(default_factory=dict)
+    headers: dict[str, str] = field(default_factory=dict)
+    context: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         """Mask sensitive data in string representation."""
@@ -100,21 +101,21 @@ class AuthResult:
     message: str
 
     # User/Session information
-    user_id: Optional[str] = None
-    project_id: Optional[str] = None
-    session_id: Optional[str] = None
+    user_id: str | None = None
+    project_id: str | None = None
+    session_id: str | None = None
 
     # Configuration
-    gateway_config: Optional[Dict[str, Any]] = None
-    mcp_config: Optional[List[Dict[str, Any]]] = None
+    gateway_config: dict[str, Any] | None = None
+    mcp_config: list[dict[str, Any]] | None = None
 
     # Permissions
-    permissions: List[str] = field(default_factory=list)
-    roles: List[str] = field(default_factory=list)
+    permissions: list[str] = field(default_factory=list)
+    roles: list[str] = field(default_factory=list)
 
     # Metadata
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    error: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
 
     @property
     def is_success(self) -> bool:
@@ -130,15 +131,15 @@ class SessionData:
 
     session_id: str
     user_id: str
-    project_id: Optional[str] = None
+    project_id: str | None = None
 
     authenticated: bool = False
     created_at: float = 0.0
     last_accessed: float = 0.0
-    expires_at: Optional[float] = None
+    expires_at: float | None = None
 
-    gateway_config: Optional[Dict[str, Any]] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    gateway_config: dict[str, Any] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 # ============================================================================
@@ -174,7 +175,7 @@ class AuthProvider(ABC):
         pass
 
     @abstractmethod
-    def get_supported_methods(self) -> List[AuthMethod]:
+    def get_supported_methods(self) -> list[AuthMethod]:
         """
         Get the authentication methods supported by this provider.
 
@@ -225,7 +226,7 @@ class AuthProvider(ABC):
         """
         pass
 
-    def validate_config(self, config: Dict[str, Any]) -> bool:
+    def validate_config(self, config: dict[str, Any]) -> bool:
         """
         Validate provider configuration.
 
@@ -237,7 +238,7 @@ class AuthProvider(ABC):
         """
         return True
 
-    def get_required_config_keys(self) -> List[str]:
+    def get_required_config_keys(self) -> list[str]:
         """
         Get list of required configuration keys.
 
@@ -282,7 +283,7 @@ class SessionManager(Protocol):
         """
         ...
 
-    def get_session(self, session_id: str) -> Optional[SessionData]:
+    def get_session(self, session_id: str) -> SessionData | None:
         """
         Get session data by ID.
 
@@ -294,7 +295,7 @@ class SessionManager(Protocol):
         """
         ...
 
-    def update_session(self, session_id: str, data: Dict[str, Any]) -> bool:
+    def update_session(self, session_id: str, data: dict[str, Any]) -> bool:
         """
         Update session data.
 
@@ -334,9 +335,7 @@ class ConfigurationProvider(Protocol):
     Protocol for providing gateway/user configuration.
     """
 
-    def get_config(
-        self, user_id: str, project_id: Optional[str] = None
-    ) -> Dict[str, Any]:
+    def get_config(self, user_id: str, project_id: str | None = None) -> dict[str, Any]:
         """
         Get configuration for a user/project.
 
@@ -362,7 +361,7 @@ class AuthProviderRegistry:
 
     def __init__(self):
         """Initialize the registry."""
-        self._provider: Optional[AuthProvider] = None
+        self._provider: AuthProvider | None = None
 
     def register(self, provider: AuthProvider) -> None:
         """
@@ -382,7 +381,7 @@ class AuthProviderRegistry:
         """
         self._provider = None
 
-    def get_provider(self, name: str = None) -> Optional[AuthProvider]:
+    def get_provider(self, name: str = None) -> AuthProvider | None:
         """
         Get the registered provider.
 
@@ -394,7 +393,7 @@ class AuthProviderRegistry:
         """
         return self._provider
 
-    def list_providers(self) -> List[str]:
+    def list_providers(self) -> list[str]:
         """
         Get list of registered provider names.
 
@@ -405,7 +404,7 @@ class AuthProviderRegistry:
             return [self._provider.get_name()]
         return []
 
-    def get_all_providers(self) -> Dict[str, AuthProvider]:
+    def get_all_providers(self) -> dict[str, AuthProvider]:
         """
         Get all registered providers.
 
@@ -424,8 +423,8 @@ class AuthProviderFactory:
 
     @staticmethod
     def create_provider(
-        provider_type: str, config: Dict[str, Any]
-    ) -> Optional[AuthProvider]:
+        provider_type: str, config: dict[str, Any]
+    ) -> AuthProvider | None:
         """
         Create a provider instance.
 
@@ -453,7 +452,7 @@ class AuthProviderFactory:
 # ============================================================================
 
 
-def mask_sensitive_value(value: Optional[str], visible_chars: int = 4) -> str:
+def mask_sensitive_value(value: str | None, visible_chars: int = 4) -> str:
     """
     Mask a sensitive value, showing only last N characters.
 

--- a/src/secure_mcp_gateway/plugins/auth/config_manager.py
+++ b/src/secure_mcp_gateway/plugins/auth/config_manager.py
@@ -94,6 +94,7 @@ class AuthConfigManager:
                 "apikey"
             )
             credentials.gateway_name = headers.get("X-Enkrypt-MCP-Gateway")
+            credentials.gateway_version = headers.get("X-Enkrypt-MCP-Gateway-Version")
             credentials.project_id = headers.get("project_id")
             credentials.user_id = headers.get("user_id")
             credentials.access_token = headers.get("Authorization", "").replace(
@@ -162,7 +163,11 @@ class AuthConfigManager:
 
         # Get local config to find mcp_config_id
         local_config = await self.get_local_mcp_config(
-            gateway_key, project_id, user_id, gateway_name=credentials.gateway_name
+            gateway_key,
+            project_id,
+            user_id,
+            gateway_name=credentials.gateway_name,
+            gateway_version=credentials.gateway_version,
         )
         if not local_config:
             return AuthResult(
@@ -375,6 +380,7 @@ class AuthConfigManager:
             "project_id": creds.project_id,
             "user_id": creds.user_id,
             "gateway_name": creds.gateway_name,
+            "gateway_version": creds.gateway_version,
         }
 
     async def get_local_mcp_config(
@@ -383,6 +389,7 @@ class AuthConfigManager:
         project_id: str = None,
         user_id: str = None,
         gateway_name: str = None,
+        gateway_version: str = None,
     ) -> dict[str, Any]:
         """
         Backward-compatible method matching auth_service.get_local_mcp_config()
@@ -393,13 +400,20 @@ class AuthConfigManager:
         ``X-Enkrypt-MCP-Gateway`` header (extracted via
         ``get_gateway_credentials``). Without it, the cloud provider can't
         identify which gateway config to fetch and the call fails.
+
+        ``gateway_version`` is the request's ``X-Enkrypt-MCP-Gateway-Version``
+        header, used unless ``auth.config.gateway_version`` is pinned.
         """
         provider = self.get_provider("enkrypt")
         if not provider or not hasattr(provider, "_get_local_config"):
             return {}
 
         return await provider._get_local_config(
-            gateway_key, project_id, user_id, gateway_name=gateway_name
+            gateway_key,
+            project_id,
+            user_id,
+            gateway_name=gateway_name,
+            gateway_version=gateway_version,
         )
 
     def create_session_key(
@@ -485,7 +499,11 @@ class AuthConfigManager:
 
         # Get MCP config to get mcp_config_id
         local_config = await self.get_local_mcp_config(
-            gateway_key, project_id, user_id, gateway_name=credentials.gateway_name
+            gateway_key,
+            project_id,
+            user_id,
+            gateway_name=credentials.gateway_name,
+            gateway_version=credentials.gateway_version,
         )
         if not local_config:
             return False
@@ -533,7 +551,11 @@ class AuthConfigManager:
             return None
 
         local_config = await self.get_local_mcp_config(
-            gateway_key, project_id, user_id, gateway_name=credentials.gateway_name
+            gateway_key,
+            project_id,
+            user_id,
+            gateway_name=credentials.gateway_name,
+            gateway_version=credentials.gateway_version,
         )
         if not local_config:
             return None
@@ -560,7 +582,11 @@ class AuthConfigManager:
             return False
 
         local_config = await self.get_local_mcp_config(
-            gateway_key, project_id, user_id, gateway_name=credentials.gateway_name
+            gateway_key,
+            project_id,
+            user_id,
+            gateway_name=credentials.gateway_name,
+            gateway_version=credentials.gateway_version,
         )
         if not local_config:
             return False
@@ -585,9 +611,14 @@ class AuthConfigManager:
             project_id = credentials.get("project_id")
             user_id = credentials.get("user_id")
             gateway_name = credentials.get("gateway_name")
+            gateway_version = credentials.get("gateway_version")
 
             local_cfg = await self.get_local_mcp_config(
-                gateway_key, project_id, user_id, gateway_name=gateway_name
+                gateway_key,
+                project_id,
+                user_id,
+                gateway_name=gateway_name,
+                gateway_version=gateway_version,
             )
             if not local_cfg:
                 return "not_provided"

--- a/src/secure_mcp_gateway/plugins/auth/enkrypt_provider.py
+++ b/src/secure_mcp_gateway/plugins/auth/enkrypt_provider.py
@@ -151,7 +151,7 @@ class EnkryptAuthProvider(AuthProvider):
         self,
         apikey: str | None = None,
         gateway_name: str | None = None,
-        gateway_version: str = DEFAULT_GATEWAY_VERSION,
+        gateway_version: str | None = None,
         project_name: str | None = None,
         base_url: str = DEFAULT_BASE_URL,
         cache_ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS,
@@ -176,6 +176,8 @@ class EnkryptAuthProvider(AuthProvider):
 
         self.apikey = apikey or ""
         self.gateway_name = gateway_name or None
+        # Pinned only when auth.config sets it; otherwise the request header wins.
+        self._gateway_version_pinned = bool(gateway_version)
         self.gateway_version = gateway_version or DEFAULT_GATEWAY_VERSION
         self.project_name = project_name or None  # treat empty string as absent
         self.base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
@@ -188,7 +190,10 @@ class EnkryptAuthProvider(AuthProvider):
             "[EnkryptAuthProvider] initialised: gateway_name=%s gateway_version=%s "
             "project_name=%s base_url=%s ttl=%ss",
             self.gateway_name or "(from request header X-Enkrypt-MCP-Gateway)",
-            self.gateway_version,
+            self.gateway_version
+            if self._gateway_version_pinned
+            else f"{self.gateway_version} (default; overridable per request via "
+            "X-Enkrypt-MCP-Gateway-Version)",
             self.project_name or "(inferred from apikey)",
             self.base_url,
             self.cache_ttl_seconds,
@@ -228,6 +233,19 @@ class EnkryptAuthProvider(AuthProvider):
         )
         return result
 
+    def _resolve_gateway_version(self, header_version: str | None) -> str:
+        """Version to send upstream: pinned config, else header, else v1."""
+        if self._gateway_version_pinned:
+            if header_version and header_version != self.gateway_version:
+                logger.info(
+                    "[EnkryptAuthProvider] ignoring X-Enkrypt-MCP-Gateway-Version "
+                    "header (%s); auth.config.gateway_version wins (%s)",
+                    header_version,
+                    self.gateway_version,
+                )
+            return self.gateway_version
+        return header_version or DEFAULT_GATEWAY_VERSION
+
     async def _authenticate_impl(self, credentials: AuthCredentials) -> AuthResult:
         gateway_key = credentials.gateway_key or credentials.api_key or self.apikey
         if not gateway_key:
@@ -266,12 +284,15 @@ class EnkryptAuthProvider(AuthProvider):
                 self.gateway_name,
             )
 
+        effective_version = self._resolve_gateway_version(credentials.gateway_version)
+
         try:
             mapped = await self._get_local_config(
                 gateway_key,
                 credentials.project_id,
                 credentials.user_id,
                 gateway_name=effective_gateway,
+                gateway_version=effective_version,
             )
         except _CloudFetchError as exc:
             return AuthResult(
@@ -310,7 +331,7 @@ class EnkryptAuthProvider(AuthProvider):
                 "source": "enkrypt-cloud",
                 "config_id": mapped.get("mcp_config_id"),
                 "gateway_name": effective_gateway,
-                "gateway_version": self.gateway_version,
+                "gateway_version": effective_version,
                 # Cloud `request_context` identity fields are promoted to
                 # top-level keys on `mapped` (so telemetry can read them
                 # straight off the gateway_config), but we also surface them
@@ -348,6 +369,7 @@ class EnkryptAuthProvider(AuthProvider):
         user_id: str | None = None,
         *,
         gateway_name: str | None = None,
+        gateway_version: str | None = None,
     ) -> dict[str, Any] | None:
         """Return the internal ``gateway_config`` dict for a given apikey.
 
@@ -360,9 +382,13 @@ class EnkryptAuthProvider(AuthProvider):
         ``gateway_name`` is the per-request header (``X-Enkrypt-MCP-Gateway``)
         the caller extracted. ``self.gateway_name`` (from ``auth.config``) wins
         when set — the header is only consulted as a fallback.
+
+        ``gateway_version`` is the per-request header; see
+        ``_resolve_gateway_version``.
         """
         effective_gateway = self.gateway_name or gateway_name
-        cache_key = self._cache_key(gateway_key, effective_gateway)
+        effective_version = self._resolve_gateway_version(gateway_version)
+        cache_key = self._cache_key(gateway_key, effective_gateway, effective_version)
         cached = self._cache_get(cache_key)
         if cached is not None:
             return cached
@@ -370,6 +396,7 @@ class EnkryptAuthProvider(AuthProvider):
         response = await self._fetch_remote_gateway_config(
             gateway_key,
             gateway_name=effective_gateway,
+            gateway_version=effective_version,
         )
         if response is None:
             return None
@@ -392,6 +419,7 @@ class EnkryptAuthProvider(AuthProvider):
         gateway_key: str,
         *,
         gateway_name: str | None = None,
+        gateway_version: str | None = None,
     ) -> dict[str, Any] | None:
         """Call ``GET /mcp-gateway/get-gateway-config`` and return the body.
 
@@ -403,6 +431,7 @@ class EnkryptAuthProvider(AuthProvider):
         fallback used only when the gateway is configured without one.
         """
         effective_gateway = self.gateway_name or gateway_name
+        effective_version = self._resolve_gateway_version(gateway_version)
         if not effective_gateway:
             # Fail clearly *before* the aiohttp call: a ``None`` header value
             # makes multidict raise ``TypeError: Cannot serialize non-str key
@@ -419,7 +448,7 @@ class EnkryptAuthProvider(AuthProvider):
         headers = {
             "apikey": gateway_key,
             "X-Enkrypt-MCP-Gateway": effective_gateway,
-            "X-Enkrypt-MCP-Gateway-Version": self.gateway_version,
+            "X-Enkrypt-MCP-Gateway-Version": effective_version,
         }
         if self.project_name:
             headers["X-Enkrypt-Project"] = self.project_name
@@ -430,7 +459,7 @@ class EnkryptAuthProvider(AuthProvider):
             "[EnkryptAuthProvider] fetching gateway config: gateway=%s/%s "
             "project=%s apikey=%s",
             effective_gateway,
-            self.gateway_version,
+            effective_version,
             self.project_name or "(inferred)",
             mask_key(gateway_key),
         )
@@ -450,7 +479,7 @@ class EnkryptAuthProvider(AuthProvider):
                 span, SpanAttributes.GATEWAY_NAME, effective_gateway
             )
             set_span_attr_with_legacy(
-                span, SpanAttributes.GATEWAY_VERSION, self.gateway_version
+                span, SpanAttributes.GATEWAY_VERSION, effective_version
             )
             # Mirror the masked ``apikey`` request header so trace consumers
             # can pivot per-tenant without ever seeing the raw secret.
@@ -806,14 +835,16 @@ class EnkryptAuthProvider(AuthProvider):
         self,
         gateway_key: str,
         effective_gateway: str | None = None,
+        effective_version: str | None = None,
     ) -> str:
         # Hash the apikey so even an in-memory dump doesn't leak it. The
         # gateway_name+version+project_name are part of the key so a single
         # process that handles multiple gateways/projects (uncommon, but
         # supported) doesn't cross-contaminate.
         gw = effective_gateway or self.gateway_name or ""
+        ver = effective_version or self.gateway_version
         h = hashlib.sha256(
-            f"{gateway_key}|{gw}|{self.gateway_version}|{self.project_name or ''}".encode()
+            f"{gateway_key}|{gw}|{ver}|{self.project_name or ''}".encode()
         ).hexdigest()
         return h[:16]
 

--- a/src/secure_mcp_gateway/plugins/auth/local_apikey_provider.py
+++ b/src/secure_mcp_gateway/plugins/auth/local_apikey_provider.py
@@ -280,11 +280,13 @@ class LocalApiKeyProvider(AuthProvider):
         project_id: str = None,
         user_id: str = None,
         gateway_name: str = None,
+        gateway_version: str = None,
     ) -> dict[str, Any] | None:
         """
         Get configuration from local config file.
 
-        ``gateway_name`` is accepted for signature parity with
+        ``gateway_name`` / ``gateway_version`` are accepted for signature
+        parity with
         :class:`EnkryptAuthProvider._get_local_config` — ``AuthConfigManager.
         get_local_mcp_config`` forwards it unconditionally as a kwarg.
         Without this parameter, every call from cloud-style call sites
@@ -292,8 +294,8 @@ class LocalApiKeyProvider(AuthProvider):
         ``TypeError: unexpected keyword argument 'gateway_name'``, which
         ``build_log_extra`` silently swallowed and left ``email`` /
         ``project_name`` / etc. stuck at ``"not_provided"`` on logs, spans
-        and metrics. The local provider has no use for the value — gateway
-        identity lives in the local file's ``apikeys`` mapping.
+        and metrics. The local provider has no use for either value —
+        gateway identity lives in the local file's ``apikeys`` mapping.
 
         Args:
             gateway_key: Gateway API key

--- a/src/secure_mcp_gateway/services/cache/cache_management_service.py
+++ b/src/secure_mcp_gateway/services/cache/cache_management_service.py
@@ -205,6 +205,7 @@ class CacheManagementService:
                 enkrypt_project_id,
                 enkrypt_user_id,
                 gateway_name=credentials.get("gateway_name"),
+                gateway_version=credentials.get("gateway_version"),
             )
 
             if not gateway_config:
@@ -250,7 +251,9 @@ class CacheManagementService:
             auth_span.set_attribute(
                 SpanAttributes.PROJECT_REGISTRY, enkrypt_project_registry
             )
-            set_span_attr_with_legacy(auth_span, SpanAttributes.USER_ID, enkrypt_user_id)
+            set_span_attr_with_legacy(
+                auth_span, SpanAttributes.USER_ID, enkrypt_user_id
+            )
             set_span_attr_with_legacy(
                 auth_span, SpanAttributes.USER_EMAIL, enkrypt_email
             )

--- a/src/secure_mcp_gateway/services/cache/cache_status_service.py
+++ b/src/secure_mcp_gateway/services/cache/cache_status_service.py
@@ -138,6 +138,7 @@ class CacheStatusService:
                 enkrypt_project_id,
                 enkrypt_user_id,
                 gateway_name=credentials.get("gateway_name"),
+                gateway_version=credentials.get("gateway_version"),
             )
 
             if not gateway_config:
@@ -190,7 +191,9 @@ class CacheStatusService:
             set_span_attr_with_legacy(
                 auth_span, SpanAttributes.PROJECT_ID, enkrypt_project_id
             )
-            set_span_attr_with_legacy(auth_span, SpanAttributes.USER_ID, enkrypt_user_id)
+            set_span_attr_with_legacy(
+                auth_span, SpanAttributes.USER_ID, enkrypt_user_id
+            )
             auth_span.set_attribute(SpanAttributes.CONFIG_ID, enkrypt_mcp_config_id)
             set_span_attr_with_legacy(
                 auth_span, SpanAttributes.PROJECT_NAME, enkrypt_project_name
@@ -422,6 +425,7 @@ class CacheStatusService:
             local_gateway_config = await self.auth_manager.get_local_mcp_config(
                 enkrypt_gateway_key,
                 gateway_name=credentials.get("gateway_name"),
+                gateway_version=credentials.get("gateway_version"),
             )
             if not local_gateway_config:
                 logger.error(

--- a/src/secure_mcp_gateway/services/discovery/discovery_service.py
+++ b/src/secure_mcp_gateway/services/discovery/discovery_service.py
@@ -120,6 +120,7 @@ class DiscoveryService:
                 enkrypt_project_id,
                 enkrypt_user_id,
                 gateway_name=credentials.get("gateway_name"),
+                gateway_version=credentials.get("gateway_version"),
             )
 
             # Generate session key if not provided (for backward compatibility)
@@ -181,7 +182,9 @@ class DiscoveryService:
             set_span_attr_with_legacy(
                 main_span, SpanAttributes.PROJECT_ID, enkrypt_project_id
             )
-            set_span_attr_with_legacy(main_span, SpanAttributes.USER_ID, enkrypt_user_id)
+            set_span_attr_with_legacy(
+                main_span, SpanAttributes.USER_ID, enkrypt_user_id
+            )
             main_span.set_attribute(SpanAttributes.CONFIG_ID, enkrypt_mcp_config_id)
             set_span_attr_with_legacy(
                 main_span, SpanAttributes.PROJECT_NAME, enkrypt_project_name
@@ -281,6 +284,7 @@ class DiscoveryService:
                     from secure_mcp_gateway.plugins.telemetry.metrics_helpers import (
                         record_discovery_failure,
                     )
+
                     record_discovery_failure(
                         server_name=server_name,
                         reason=type(e).__name__,
@@ -1087,7 +1091,9 @@ class DiscoveryService:
         """Discover tools for a single server."""
         # Server info check
         with tracer_obj.start_as_current_span("get_server_info") as info_span:
-            set_span_attr_with_legacy(info_span, SpanAttributes.SERVER_NAME, server_name)
+            set_span_attr_with_legacy(
+                info_span, SpanAttributes.SERVER_NAME, server_name
+            )
 
             server_info = get_server_info_by_name(
                 self.auth_manager.get_session_gateway_config(session_key), server_name
@@ -2057,9 +2063,7 @@ class DiscoveryService:
                     ):
                         telemetry_manager.cache_hit_counter.add(
                             1,
-                            attributes=build_log_extra(
-                                ctx, server_name=server_name
-                            ),
+                            attributes=build_log_extra(ctx, server_name=server_name),
                         )
                     logger.info(
                         f"[discover_server_tools] Tools already cached for {server_name}"
@@ -2088,9 +2092,7 @@ class DiscoveryService:
                     ):
                         telemetry_manager.cache_miss_counter.add(
                             1,
-                            attributes=build_log_extra(
-                                ctx, server_name=server_name
-                            ),
+                            attributes=build_log_extra(ctx, server_name=server_name),
                         )
                     logger.info(
                         f"[discover_server_tools] No cached tools found for {server_name}"

--- a/src/secure_mcp_gateway/services/execution/secure_tool_execution_service.py
+++ b/src/secure_mcp_gateway/services/execution/secure_tool_execution_service.py
@@ -365,6 +365,7 @@ class SecureToolExecutionService:
                     creds.get("project_id"),
                     creds.get("user_id"),
                     gateway_name=creds.get("gateway_name"),
+                    gateway_version=creds.get("gateway_version"),
                 )
 
                 if not local_config:

--- a/src/secure_mcp_gateway/services/server/server_info_service.py
+++ b/src/secure_mcp_gateway/services/server/server_info_service.py
@@ -81,6 +81,7 @@ class ServerInfoService:
             enkrypt_project_id,
             enkrypt_user_id,
             gateway_name=credentials.get("gateway_name"),
+            gateway_version=credentials.get("gateway_version"),
         )
 
         if not gateway_config:
@@ -119,7 +120,9 @@ class ServerInfoService:
         session_key = f"{enkrypt_gateway_key}_{enkrypt_project_id}_{enkrypt_user_id}_{enkrypt_mcp_config_id}"
 
         with tracer.start_as_current_span(SpanNames.SERVER_INFO) as main_span:
-            set_span_attr_with_legacy(main_span, SpanAttributes.SERVER_NAME, server_name)
+            set_span_attr_with_legacy(
+                main_span, SpanAttributes.SERVER_NAME, server_name
+            )
             main_span.set_attribute(SpanAttributes.JOB, "enkrypt")
             main_span.set_attribute(SpanAttributes.ENV, "dev")
             main_span.set_attribute(SpanAttributes.CUSTOM_ID, custom_id)
@@ -136,7 +139,9 @@ class ServerInfoService:
             set_span_attr_with_legacy(
                 main_span, SpanAttributes.PROJECT_ID, enkrypt_project_id
             )
-            set_span_attr_with_legacy(main_span, SpanAttributes.USER_ID, enkrypt_user_id)
+            set_span_attr_with_legacy(
+                main_span, SpanAttributes.USER_ID, enkrypt_user_id
+            )
             main_span.set_attribute(SpanAttributes.CONFIG_ID, enkrypt_mcp_config_id)
             set_span_attr_with_legacy(
                 main_span, SpanAttributes.PROJECT_NAME, enkrypt_project_name
@@ -405,7 +410,9 @@ class ServerInfoService:
     ):
         """Get latest server info with all attributes."""
         with tracer.start_as_current_span(SpanNames.SERVER_INFO_LATEST) as info_span:
-            set_span_attr_with_legacy(info_span, SpanAttributes.SERVER_NAME, server_name)
+            set_span_attr_with_legacy(
+                info_span, SpanAttributes.SERVER_NAME, server_name
+            )
             info_span.set_attribute(
                 SpanAttributes.GATEWAY_KEY, mask_key(enkrypt_gateway_key)
             )

--- a/src/secure_mcp_gateway/services/server/server_listing_service.py
+++ b/src/secure_mcp_gateway/services/server/server_listing_service.py
@@ -95,6 +95,7 @@ class ServerListingService:
                 enkrypt_project_id,
                 enkrypt_user_id,
                 gateway_name=credentials.get("gateway_name"),
+                gateway_version=credentials.get("gateway_version"),
             )
 
             if not gateway_config:

--- a/src/secure_mcp_gateway/utils.py
+++ b/src/secure_mcp_gateway/utils.py
@@ -651,6 +651,7 @@ def build_log_extra(ctx, custom_id=None, server_name=None, error=None, **kwargs)
             project_id = credentials.get("project_id", project_id)
             user_id = credentials.get("user_id", user_id)
             gateway_name = credentials.get("gateway_name")
+            header_gateway_version = credentials.get("gateway_version")
 
             if gateway_key:
                 try:
@@ -673,6 +674,7 @@ def build_log_extra(ctx, custom_id=None, server_name=None, error=None, **kwargs)
                                         project_id,
                                         user_id,
                                         gateway_name=gateway_name,
+                                        gateway_version=header_gateway_version,
                                     )
                                 )
                                 or {}

--- a/src/secure_mcp_gateway/version.py
+++ b/src/secure_mcp_gateway/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"

--- a/tests/test_enkrypt_auth_provider.py
+++ b/tests/test_enkrypt_auth_provider.py
@@ -997,3 +997,167 @@ def test_create_session_key_store_lookup_symmetry() -> None:
     )
 
     assert store_key == lookup_via_helper == lookup_via_inline_fstring
+
+
+# ---------------------------------------------------------------------------
+# gateway_version resolution: pinned auth.config wins, else request header
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_leaves_version_unpinned_by_default() -> None:
+    p = EnkryptAuthProvider(apikey="x", gateway_name="g")
+    assert p.gateway_version == "v1"
+    assert p._gateway_version_pinned is False
+
+
+def test_constructor_marks_version_pinned_when_configured() -> None:
+    p = EnkryptAuthProvider(apikey="x", gateway_name="g", gateway_version="2")
+    assert p.gateway_version == "2"
+    assert p._gateway_version_pinned is True
+
+
+def test_resolve_gateway_version_precedence() -> None:
+    unpinned = EnkryptAuthProvider(apikey="x")
+    assert unpinned._resolve_gateway_version("1") == "1"
+    assert unpinned._resolve_gateway_version(None) == "v1"
+    assert unpinned._resolve_gateway_version("") == "v1"
+
+    pinned = EnkryptAuthProvider(apikey="x", gateway_version="v3")
+    assert pinned._resolve_gateway_version("1") == "v3"
+    assert pinned._resolve_gateway_version(None) == "v3"
+
+
+@pytest.mark.asyncio
+async def test_authenticate_uses_header_gateway_version(monkeypatch) -> None:
+    """Unpinned config: the request header decides the version."""
+    p = EnkryptAuthProvider(apikey="x", base_url="https://api.example.com")
+
+    seen: Dict[str, Any] = {}
+
+    async def fake_fetch(self: EnkryptAuthProvider, gateway_key: str, **kw):
+        seen.update(kw)
+        return sample_response()
+
+    async def empty_overrides(self: EnkryptAuthProvider):
+        return {}
+
+    monkeypatch.setattr(EnkryptAuthProvider, "_fetch_remote_gateway_config", fake_fetch)
+    monkeypatch.setattr(
+        EnkryptAuthProvider, "_load_local_server_overrides", empty_overrides
+    )
+
+    creds = AuthCredentials(
+        api_key="x",
+        gateway_key="x",
+        gateway_name="demo-mcp-gateway",
+        gateway_version="1",
+    )
+    result = await p.authenticate(creds)
+    assert result.authenticated is True
+    assert seen["gateway_name"] == "demo-mcp-gateway"
+    assert seen["gateway_version"] == "1"
+    assert result.metadata["gateway_version"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_authenticate_config_gateway_version_wins_over_header(
+    monkeypatch,
+) -> None:
+    """Pinned config beats the client header."""
+    p = make_provider()  # config pins gateway_version="v1"
+
+    seen: Dict[str, Any] = {}
+
+    async def fake_fetch(self: EnkryptAuthProvider, gateway_key: str, **kw):
+        seen.update(kw)
+        return sample_response()
+
+    async def empty_overrides(self: EnkryptAuthProvider):
+        return {}
+
+    monkeypatch.setattr(EnkryptAuthProvider, "_fetch_remote_gateway_config", fake_fetch)
+    monkeypatch.setattr(
+        EnkryptAuthProvider, "_load_local_server_overrides", empty_overrides
+    )
+
+    creds = AuthCredentials(api_key="x", gateway_key="x", gateway_version="9")
+    result = await p.authenticate(creds)
+    assert result.authenticated is True
+    assert seen["gateway_version"] == "v1"
+    assert result.metadata["gateway_version"] == "v1"
+
+
+@pytest.mark.asyncio
+async def test_fetch_sends_resolved_version_header(monkeypatch) -> None:
+    """Resolved version lands on the outbound request header."""
+    p = EnkryptAuthProvider(apikey="x", base_url="https://api.example.com")
+
+    captured: Dict[str, Any] = {}
+
+    class _FakeResponse:
+        status = 200
+
+        async def json(self):
+            return sample_response()
+
+        async def text(self):
+            return "{}"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def get(self, url, headers=None, timeout=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return _FakeResponse()
+
+    monkeypatch.setattr(ep_mod.aiohttp, "ClientSession", lambda *a, **k: _FakeSession())
+
+    await p._fetch_remote_gateway_config(
+        "apikey-value", gateway_name="demo-mcp-gateway", gateway_version="1"
+    )
+    assert captured["headers"]["X-Enkrypt-MCP-Gateway"] == "demo-mcp-gateway"
+    assert captured["headers"]["X-Enkrypt-MCP-Gateway-Version"] == "1"
+
+
+def test_cache_key_separates_versions() -> None:
+    """Two versions of one gateway must not share a cache entry."""
+    p = EnkryptAuthProvider(apikey="x")
+    k1 = p._cache_key("apikey", "demo-mcp-gateway", "1")
+    k2 = p._cache_key("apikey", "demo-mcp-gateway", "v1")
+    assert k1 != k2
+
+
+@pytest.mark.asyncio
+async def test_get_local_config_caches_per_version(monkeypatch) -> None:
+    """Each version is fetched and cached independently."""
+    p = EnkryptAuthProvider(apikey="x", base_url="https://api.example.com")
+
+    calls = []
+
+    async def fake_fetch(self: EnkryptAuthProvider, gateway_key: str, **kw):
+        calls.append(kw.get("gateway_version"))
+        return sample_response()
+
+    async def empty_overrides(self: EnkryptAuthProvider):
+        return {}
+
+    monkeypatch.setattr(EnkryptAuthProvider, "_fetch_remote_gateway_config", fake_fetch)
+    monkeypatch.setattr(
+        EnkryptAuthProvider, "_load_local_server_overrides", empty_overrides
+    )
+
+    await p._get_local_config("k", gateway_name="gw", gateway_version="1")
+    await p._get_local_config("k", gateway_name="gw", gateway_version="1")
+    await p._get_local_config("k", gateway_name="gw", gateway_version="v2")
+    assert calls == ["1", "v2"]

--- a/tests/test_gateway_version_header.py
+++ b/tests/test_gateway_version_header.py
@@ -1,0 +1,108 @@
+"""``X-Enkrypt-MCP-Gateway-Version`` extraction and manager plumbing.
+
+Provider-side precedence lives in ``test_enkrypt_auth_provider.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from secure_mcp_gateway.plugins.auth.config_manager import AuthConfigManager
+
+
+def _ctx(headers: dict[str, str]) -> SimpleNamespace:
+    """Minimal stand-in for an MCP ``Context`` carrying HTTP headers."""
+    return SimpleNamespace(
+        request_context=SimpleNamespace(request=SimpleNamespace(headers=headers))
+    )
+
+
+@pytest.fixture()
+def manager(monkeypatch) -> AuthConfigManager:
+    # extract_credentials falls back to these, which would mask the headers.
+    for var in (
+        "ENKRYPT_APIKEY",
+        "ENKRYPT_GATEWAY_KEY",
+        "ENKRYPT_PROJECT_ID",
+        "ENKRYPT_USER_ID",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return AuthConfigManager()
+
+
+def test_extract_credentials_reads_version_header(manager) -> None:
+    creds = manager.extract_credentials(
+        _ctx(
+            {
+                "apikey": "cloud-key",
+                "X-Enkrypt-MCP-Gateway": "demo-mcp-gateway",
+                "X-Enkrypt-MCP-Gateway-Version": "1",
+            }
+        )
+    )
+    assert creds.gateway_name == "demo-mcp-gateway"
+    assert creds.gateway_version == "1"
+
+
+def test_extract_credentials_version_absent_is_none(manager) -> None:
+    """Absent header stays ``None`` so the provider applies its default."""
+    creds = manager.extract_credentials(
+        _ctx({"apikey": "cloud-key", "X-Enkrypt-MCP-Gateway": "demo-mcp-gateway"})
+    )
+    assert creds.gateway_version is None
+
+
+def test_get_gateway_credentials_exposes_version(manager) -> None:
+    """Service layer reads credentials through this dict."""
+    creds = manager.get_gateway_credentials(
+        _ctx(
+            {
+                "apikey": "cloud-key",
+                "X-Enkrypt-MCP-Gateway": "demo-mcp-gateway",
+                "X-Enkrypt-MCP-Gateway-Version": "1",
+            }
+        )
+    )
+    assert creds["gateway_version"] == "1"
+    assert creds["gateway_name"] == "demo-mcp-gateway"
+
+
+@pytest.mark.asyncio
+async def test_get_local_mcp_config_forwards_version(manager, monkeypatch) -> None:
+    """The manager hands the version to the provider unchanged."""
+    seen: dict[str, object] = {}
+
+    class _StubProvider:
+        async def _get_local_config(self, gateway_key, project_id=None, user_id=None,
+                                    *, gateway_name=None, gateway_version=None):
+            seen.update(
+                gateway_key=gateway_key,
+                gateway_name=gateway_name,
+                gateway_version=gateway_version,
+            )
+            return {"mcp_config_id": "cfg-1"}
+
+    monkeypatch.setattr(manager, "get_provider", lambda name=None: _StubProvider())
+
+    out = await manager.get_local_mcp_config(
+        "cloud-key", None, None, gateway_name="demo-mcp-gateway", gateway_version="1"
+    )
+    assert out == {"mcp_config_id": "cfg-1"}
+    assert seen["gateway_name"] == "demo-mcp-gateway"
+    assert seen["gateway_version"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_local_apikey_provider_tolerates_version_kwarg() -> None:
+    """Local mode must not raise ``TypeError`` on the forwarded kwarg."""
+    from secure_mcp_gateway.plugins.auth.local_apikey_provider import (
+        LocalApiKeyProvider,
+    )
+
+    provider = LocalApiKeyProvider()
+    result = await provider._get_local_config(
+        "no-such-key", None, None, gateway_name="ignored", gateway_version="1"
+    )
+    assert result in (None, {}, )


### PR DESCRIPTION
## Problem

Enkrypt cloud looks a gateway up by the pair `(gateway_saved_name, gateway_version)`, but the gateway only ever read `X-Enkrypt-MCP-Gateway` from the client. The version came exclusively from `plugins.auth.config.gateway_version`, defaulting to `"v1"`.

Any gateway registered under a different version string (`1`, `v2`, ...) was therefore unreachable from a header-routed deployment — `/mcp-gateway/get-gateway-config` returned `404 {"message": "MCP gateway not found"}` on every request and surfaced to the MCP client as an auth error, no matter what version the client sent.

Hit in production: `demo-mcp-gateway` is registered as version `1`, the pod sends `v1`.

## Fix

The version now resolves exactly like the name — first match wins:

1. `plugins.auth.config.gateway_version` when pinned (a differing header is logged at INFO and dropped)
2. the `X-Enkrypt-MCP-Gateway-Version` request header
3. `"v1"`

It counts as *pinned* only when it actually appears in `auth.config`, so configs that set it keep identical behaviour and configs that omit it gain per-request routing instead of a silent `v1`.

The resolved version is threaded through the provider, the outbound request header, the `enkrypt.gateway.version` span attribute, `AuthResult.metadata`, and the in-process cache key — so two versions of one gateway can't collide in the cache. `LocalApiKeyProvider` accepts and ignores the new kwarg for signature parity.

## Also in here

- README section 7.1 documents the `enkrypt` cloud auth provider and its full header contract (inbound + outbound), which wasn't covered before
- `CLAUDE.md`: minimal-comment / high-level-changelog convention
- patch bump to `2.2.2`

## Testing

13 new tests (`tests/test_gateway_version_header.py` + a `gateway_version` block in `test_enkrypt_auth_provider.py`) covering precedence both ways, the outbound header, per-version cache separation, and local-provider parity.

Full suite: **503 passed, 5 failed** — all 5 fail identically on `main` (Docker daemon not running, two that read the developer's local `~/.enkrypt` config, and two asserting a 180s discovery timeout against the current 540s default).

## Deploy note

Once an image with this ships, the prod client config works as written and no cloud-side change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)